### PR TITLE
GLog include fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,7 +42,7 @@ if(MSVC)
         message(STATUS "- MSVC: Disabled generic compiletime warnings")
     endif()
     
-    ADD_DEFINITIONS (/D _CRT_SECURE_NO_WARNINGS /D _SCL_SECURE_NO_WARNINGS)
+    ADD_DEFINITIONS (/D _CRT_SECURE_NO_WARNINGS /D _SCL_SECURE_NO_WARNINGS /D WIN32_LEAN_AND_MEAN)
     MESSAGE(STATUS "- MSVC: Disabled NON-SECURE warnings")
         
     ADD_DEFINITIONS (/D __TBB_NO_IMPLICIT_LINKAGE=1)


### PR DESCRIPTION
Fixes issues with including GLog by defining WIN32_LEAN_AND_MEAN at the project level with cmake.
