### PR TITLE
More cleanup on events

### DIFF
--- a/src/anh/event_dispatcher/basic_event.h
+++ b/src/anh/event_dispatcher/basic_event.h
@@ -31,7 +31,7 @@ namespace anh {
 namespace event_dispatcher {
 
 template<typename T>
-class BasicEvent : public std::remove_reference<T>::type, public EventInterface {
+class BasicEvent : public std::decay<T>::type, public EventInterface {
 public:
     BasicEvent()
         : type_(std::remove_reference<T>::type::type())

--- a/src/anh/event_dispatcher/basic_event.h
+++ b/src/anh/event_dispatcher/basic_event.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <type_traits>
 
+#include <tbb/spin_rw_mutex.h>
+
 #include "anh/hash_string.h"
 #include "anh/event_dispatcher/event_interface.h"
 
@@ -60,31 +62,38 @@ public:
         return type_; 
     }
 
-    const T& data() const { 
+    T data() { 
+        tbb::spin_rw_mutex::scoped_lock lock(spin_mutex_, false);
         return data_; 
     }
 
     void data(T& data ) { 
+        tbb::spin_rw_mutex::scoped_lock lock(spin_mutex_, true);
         data_ = data; 
     }
 
-    uint32_t priority() const {
+    uint32_t priority() {
+        tbb::spin_rw_mutex::scoped_lock lock(spin_mutex_, false);
         return priority_;
     }
 
     void priority(uint32_t priority) {
+        tbb::spin_rw_mutex::scoped_lock lock(spin_mutex_, true);
         priority_ = priority;
     }
     
-    uint64_t timestamp() const {
+    uint64_t timestamp() {
+        tbb::spin_rw_mutex::scoped_lock lock(spin_mutex_, false);
         return timestamp_;
     }
     
     void timestamp(uint64_t timestamp)  {
+        tbb::spin_rw_mutex::scoped_lock lock(spin_mutex_, true);
         timestamp_ = timestamp;
     }
 
 private:
+    tbb::spin_rw_mutex spin_mutex_;
     T data_;
     EventType type_;
     uint64_t timestamp_;

--- a/src/anh/event_dispatcher/basic_event.h
+++ b/src/anh/event_dispatcher/basic_event.h
@@ -31,12 +31,12 @@ namespace anh {
 namespace event_dispatcher {
 
 template<typename T>
-class BasicEvent : public std::decay<T>::type, public EventInterface {
+class BasicEvent : public EventInterface {
 public:
     BasicEvent()
-        : type_(std::remove_reference<T>::type::type())
+        : type_(std::decay<T>::type::type())
         , timestamp_(0)
-        , priority_(std::remove_reference<T>::type::priority()) {}
+        , priority_(std::decay<T>::type::priority()) {}
     
     explicit BasicEvent(EventType type)
         : type_(std::move(type))
@@ -44,7 +44,7 @@ public:
         , priority_(0) {}
     
     BasicEvent(EventType type, T&& data)
-        : std::remove_reference<T>::type(std::forward<T>(data))
+        : data_(std::forward<T>(data))
         , type_(std::move(type))
         , timestamp_(0)
         , priority_(0) {}
@@ -57,6 +57,10 @@ public:
     ~BasicEvent() {}
 
     const EventType& type() { return type_; }
+
+    T& data() { return data_; }
+
+    const T& cdata() const { return data_; }
 
     uint32_t priority() const {
         return priority_;
@@ -75,6 +79,7 @@ public:
     }
 
 private:
+    T data_;
     EventType type_;
     uint64_t timestamp_;
     uint32_t priority_;

--- a/src/anh/event_dispatcher/basic_event.h
+++ b/src/anh/event_dispatcher/basic_event.h
@@ -56,11 +56,17 @@ public:
 
     ~BasicEvent() {}
 
-    const EventType& type() { return type_; }
+    const EventType& type() const { 
+        return type_; 
+    }
 
-    T& data() { return data_; }
+    const T& data() const { 
+        return data_; 
+    }
 
-    const T& cdata() const { return data_; }
+    void data(T& data ) { 
+        data_ = data; 
+    }
 
     uint32_t priority() const {
         return priority_;

--- a/src/anh/event_dispatcher/basic_event_unittest.cc
+++ b/src/anh/event_dispatcher/basic_event_unittest.cc
@@ -37,8 +37,8 @@ TEST(BasicEventTest, CanMakeEvent) {
 
     auto my_event = make_event("SomeEvent", std::move(test_data));
     
-    EXPECT_EQ("test string", my_event.test_string);
-    EXPECT_EQ(12345, my_event.test_int);
+    EXPECT_EQ("test string", my_event.data().test_string);
+    EXPECT_EQ(12345, my_event.data().test_int);
 }
 
 TEST(BasicEventTest, CanMakeSharedEvent) {
@@ -48,8 +48,8 @@ TEST(BasicEventTest, CanMakeSharedEvent) {
 
     auto my_event = make_shared_event("SomeEvent", std::move(test_data));
 
-    EXPECT_EQ("test string", my_event->test_string);
-    EXPECT_EQ(12345, my_event->test_int);
+    EXPECT_EQ("test string", my_event->data().test_string);
+    EXPECT_EQ(12345, my_event->data().test_int);
 }
 
 TEST(BasicEventTest, CanMakeSimpleEvent) {

--- a/src/anh/event_dispatcher/basic_event_unittest.cc
+++ b/src/anh/event_dispatcher/basic_event_unittest.cc
@@ -26,6 +26,15 @@ using namespace std;
 using namespace anh::event_dispatcher;
 
 struct TestEventData {
+    void serialize(anh::ByteBuffer& buffer) const {
+        buffer << test_string;
+        buffer << test_int;
+    }
+    void deserialize(anh::ByteBuffer buffer) {
+        test_string = buffer.read<string>();
+        test_int = buffer.read<int>();
+    }
+
     string test_string;
     int test_int;
 };

--- a/src/anh/event_dispatcher/basic_event_unittest.cc
+++ b/src/anh/event_dispatcher/basic_event_unittest.cc
@@ -1,0 +1,65 @@
+/*
+ This file is part of MMOServer. For more information, visit http://swganh.com
+ 
+ Copyright (c) 2006 - 2010 The SWG:ANH Team
+
+ MMOServer is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ MMOServer is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with MMOServer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+ 
+#include <string>
+#include <gtest/gtest.h>
+ 
+#include "anh/event_dispatcher/basic_event.h"
+ 
+using namespace std;
+using namespace anh::event_dispatcher;
+
+struct TestEventData {
+    string test_string;
+    int test_int;
+};
+
+TEST(BasicEventTest, CanMakeEvent) {
+    TestEventData test_data;
+    test_data.test_string = "test string";
+    test_data.test_int = 12345;
+
+    auto my_event = make_event("SomeEvent", std::move(test_data));
+    
+    EXPECT_EQ("test string", my_event.test_string);
+    EXPECT_EQ(12345, my_event.test_int);
+}
+
+TEST(BasicEventTest, CanMakeSharedEvent) {
+    TestEventData test_data;
+    test_data.test_string = "test string";
+    test_data.test_int = 12345;
+
+    auto my_event = make_shared_event("SomeEvent", std::move(test_data));
+
+    EXPECT_EQ("test string", my_event->test_string);
+    EXPECT_EQ(12345, my_event->test_int);
+}
+
+TEST(BasicEventTest, CanMakeSimpleEvent) {
+    auto my_event = make_event("SomeEvent");
+
+    EXPECT_EQ("SomeEvent", my_event.type().ident_string());
+}
+
+TEST(BasicEventTest, CanMakeSimpleSharedEvent) {
+    auto my_event = make_shared_event("SomeEvent");
+
+    EXPECT_EQ("SomeEvent", my_event->type().ident_string());
+}

--- a/src/anh/event_dispatcher/basic_event_unittest.cc
+++ b/src/anh/event_dispatcher/basic_event_unittest.cc
@@ -63,3 +63,9 @@ TEST(BasicEventTest, CanMakeSimpleSharedEvent) {
 
     EXPECT_EQ("SomeEvent", my_event->type().ident_string());
 }
+
+TEST(BasicEventTest, CanMakeEventFromHash) {
+    auto my_event = make_event(0xDEADBABE);
+
+    EXPECT_EQ(0xDEADBABE, my_event.type().ident());
+}

--- a/src/anh/event_dispatcher/basic_event_unittest.cc
+++ b/src/anh/event_dispatcher/basic_event_unittest.cc
@@ -26,6 +26,7 @@ using namespace std;
 using namespace anh::event_dispatcher;
 
 struct TestEventData {
+    virtual ~TestEventData() {}
     void serialize(anh::ByteBuffer& buffer) const {
         buffer << test_string;
         buffer << test_int;
@@ -46,8 +47,8 @@ TEST(BasicEventTest, CanMakeEvent) {
 
     auto my_event = make_event("SomeEvent", std::move(test_data));
     
-    EXPECT_EQ("test string", my_event.data().test_string);
-    EXPECT_EQ(12345, my_event.data().test_int);
+    EXPECT_EQ("test string", my_event.test_string);
+    EXPECT_EQ(12345, my_event.test_int);
 }
 
 TEST(BasicEventTest, CanMakeSharedEvent) {
@@ -57,8 +58,8 @@ TEST(BasicEventTest, CanMakeSharedEvent) {
 
     auto my_event = make_shared_event("SomeEvent", std::move(test_data));
 
-    EXPECT_EQ("test string", my_event->data().test_string);
-    EXPECT_EQ(12345, my_event->data().test_int);
+    EXPECT_EQ("test string", my_event->test_string);
+    EXPECT_EQ(12345, my_event->test_int);
 }
 
 TEST(BasicEventTest, CanMakeSimpleEvent) {

--- a/src/anh/event_dispatcher/event_dispatcher.h
+++ b/src/anh/event_dispatcher/event_dispatcher.h
@@ -29,6 +29,14 @@
 namespace anh {
 namespace event_dispatcher {
     
+typedef std::pair<uint64_t, EventListenerCallback> EventListener;
+typedef std::list<EventListener> EventListenerList;
+typedef std::map<EventType, EventListenerList> EventListenerMap;
+typedef std::set<EventType> EventTypeSet;
+typedef std::tuple<std::shared_ptr<EventInterface>, boost::optional<TriggerCondition>, boost::optional<PostTriggerCallback>> EventQueueItem;
+typedef tbb::concurrent_queue<EventQueueItem> EventQueue;
+typedef std::deque<EventQueue> EventQueueList;
+    
 class EventDispatcher : public EventDispatcherInterface {
 public:
     enum constants {    
@@ -67,7 +75,7 @@ public:
 private:
     bool validateEventType_(const EventType& event_type) const;
     uint32_t calculatePlacementQueue_(uint32_t priority = 0) const;
-
+    
     EventTypeSet registered_event_types_;
     EventListenerMap event_listeners_;
     EventQueueList event_queues_;

--- a/src/anh/event_dispatcher/event_dispatcher_interface.h
+++ b/src/anh/event_dispatcher/event_dispatcher_interface.h
@@ -80,62 +80,6 @@ public:
     virtual bool tick(uint64_t timeout_ms = INFINITE_TIMEOUT) = 0;
 };
 
-class NullEventDispatcher : public EventDispatcherInterface {
-public:
-    ~NullEventDispatcher() {}
-    
-    uint64_t subscribe(
-        const EventType& event_type, 
-        EventListenerCallback listener) 
-    {
-        return 0;
-    }
-
-    void unsubscribe(const EventType& event_type, uint64_t listener_id) {}
-    void unsubscribe(const EventType& event_type) {}
-
-    bool trigger(std::shared_ptr<EventInterface> incoming_event) {
-        return false;
-    }
-
-    bool trigger(
-        std::shared_ptr<EventInterface> incoming_event, 
-        PostTriggerCallback callback) 
-    { 
-        return false;
-    }
-    
-    void triggerWhen(
-        std::shared_ptr<EventInterface> incoming_event, 
-        TriggerCondition condition) 
-    {}
-
-    void triggerWhen(
-        std::shared_ptr<EventInterface> incoming_event, 
-        TriggerCondition condition, 
-        PostTriggerCallback callback)
-    {}
-
-    bool triggerAsync(std::shared_ptr<EventInterface> incoming_event) {
-        return false;
-    }
-
-    bool triggerAsync(
-        std::shared_ptr<EventInterface> incoming_event, 
-        PostTriggerCallback callback) 
-    {
-        return false;
-    }
-
-    bool abort(const EventType& event_type, bool all_of_type = false) {
-        return false;
-    }
-
-    bool tick(uint64_t timeout_ms = INFINITE_TIMEOUT) {
-        return false;
-    }
-};
-
 }  // namespace event_dispatcher
 }  // namespace anh
 

--- a/src/anh/event_dispatcher/event_dispatcher_interface.h
+++ b/src/anh/event_dispatcher/event_dispatcher_interface.h
@@ -40,18 +40,9 @@ namespace anh {
 namespace event_dispatcher {
     
 typedef std::function<bool (std::shared_ptr<EventInterface>)> EventListenerCallback;
-
-typedef std::pair<uint64_t, EventListenerCallback> EventListener;
-typedef std::list<EventListener> EventListenerList;
-typedef std::map<EventType, EventListenerList> EventListenerMap;
-typedef std::set<EventType> EventTypeSet;
-
 typedef std::function<bool (uint64_t current_time_ms)> TriggerCondition;
 typedef std::function<void (std::shared_ptr<EventInterface>, bool)> PostTriggerCallback;
 
-typedef std::tuple<std::shared_ptr<EventInterface>, boost::optional<TriggerCondition>, boost::optional<PostTriggerCallback>> EventQueueItem;
-typedef tbb::concurrent_queue<EventQueueItem> EventQueue;
-typedef std::deque<EventQueue> EventQueueList;
 
 class EventDispatcherInterface {
 public:

--- a/src/anh/event_dispatcher/event_dispatcher_unittest.cc
+++ b/src/anh/event_dispatcher/event_dispatcher_unittest.cc
@@ -135,7 +135,7 @@ TEST(EventDispatcherTest, TriggeringEventNotifiesListeners) {
     
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event = make_shared<SimpleEvent>("some_event_type");
+    auto my_event = make_shared_event("some_event_type");
 
     EXPECT_TRUE(dispatcher.trigger(my_event));
 
@@ -153,7 +153,7 @@ TEST(EventDispatcherTest, TriggeringAsyncQueuesEvent) {
     
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event = make_shared<SimpleEvent>("some_event_type");
+    auto my_event = make_shared_event("some_event_type");
 
     EXPECT_TRUE(dispatcher.triggerAsync(my_event));
 
@@ -170,7 +170,7 @@ TEST(EventDispatcherTest, TickingDispatchesQueuedEvents) {
     
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event = make_shared<SimpleEvent>("some_event_type");
+    auto my_event = make_shared_event("some_event_type");
 
     EXPECT_TRUE(dispatcher.triggerAsync(my_event));
     EXPECT_TRUE(dispatcher.hasEvents());
@@ -188,7 +188,7 @@ TEST(EventDispatcherTest, AbortingEventCancelsFirstOccurance) {
     
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event = make_shared<SimpleEvent>("some_event_type");
+    auto my_event = make_shared_event("some_event_type");
 
     EXPECT_TRUE(dispatcher.triggerAsync(my_event));
     EXPECT_TRUE(dispatcher.hasEvents());
@@ -213,7 +213,7 @@ TEST(EventDispatcherTest, CanAbortAllEventOccurrances) {
     
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event = make_shared<SimpleEvent>("some_event_type");
+    auto my_event = make_shared_event("some_event_type");
 
     // load up multiples and ensure all are removed    
     EXPECT_TRUE(dispatcher.triggerAsync(my_event));
@@ -269,7 +269,7 @@ TEST(EventDispatcherTest, CallbackIsTriggeredAfterEventProcessing) {
     
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event = make_shared<SimpleEvent>("some_event_type");
+    auto my_event = make_shared_event("some_event_type");
 
     bool callback_triggered = false;
     dispatcher.trigger(my_event, [&callback_triggered] (
@@ -291,7 +291,7 @@ TEST(EventDispatcherTest, CallbackIsTriggeredAfterQueuedEventProcessing) {
     };    
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event = make_shared<SimpleEvent>("some_event_type");
+    auto my_event = make_shared_event("some_event_type");
 
     // load up multiples and ensure all are removed    
     bool callback_triggered = false;
@@ -317,7 +317,7 @@ TEST(EventDispatcherTest, EventWaitsForCondition) {
     
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event = make_shared<SimpleEvent>("some_event_type");
+    auto my_event = make_shared_event("some_event_type");
 
     bool callback_triggered = false;
     bool proceed = false;
@@ -354,8 +354,8 @@ TEST(EventDispatcherTest, TriggeringEventSetsTimestamp) {
     
     dispatcher.subscribe("some_event_type", my_listener);
 
-    auto my_event1 = make_shared<SimpleEvent>("some_event_type");
-    auto my_event2 = make_shared<SimpleEvent>("some_event_type");
+    auto my_event1 = make_shared_event("some_event_type");
+    auto my_event2 = make_shared_event("some_event_type");
 
     EXPECT_TRUE(dispatcher.trigger(my_event1));
     EXPECT_TRUE(dispatcher.triggerAsync(my_event2));

--- a/src/anh/event_dispatcher/event_dispatcher_unittest.cc
+++ b/src/anh/event_dispatcher/event_dispatcher_unittest.cc
@@ -28,12 +28,6 @@
 using namespace std;
 using namespace anh::event_dispatcher;
 
-struct TestEventData {
-    std::string test_string;
-    int test_int;
-};
-
-
 /// By default a new instance of the dispatcher should not have any listeners.
 TEST(EventDispatcherTest, HasNoListenersByDefault) {
     EventDispatcher dispatcher;
@@ -381,38 +375,4 @@ TEST(EventDispatcherTest, SubscribingWithInvalidEventTypeThrows) {
     ASSERT_THROW(
         dispatcher.subscribe("", my_listener), 
         anh::event_dispatcher::InvalidEventType);
-}
-
-TEST(EventDispatcherTest, CanMakeEvent) {
-    TestEventData test_data;
-    test_data.test_string = "test string";
-    test_data.test_int = 12345;
-
-    auto my_event = make_event("SomeEvent", std::move(test_data));
-    
-    EXPECT_EQ("test string", my_event.test_string);
-    EXPECT_EQ(12345, my_event.test_int);
-}
-
-TEST(EventDispatcherTest, CanMakeSharedEvent) {
-    TestEventData test_data;
-    test_data.test_string = "test string";
-    test_data.test_int = 12345;
-
-    auto my_event = make_shared_event("SomeEvent", std::move(test_data));
-
-    EXPECT_EQ("test string", my_event->test_string);
-    EXPECT_EQ(12345, my_event->test_int);
-}
-
-TEST(EventDispatcherTest, CanMakeSimpleEvent) {
-    auto my_event = make_event("SomeEvent");
-
-    EXPECT_EQ("SomeEvent", my_event.type().ident_string());
-}
-
-TEST(EventDispatcherTest, CanMakeSimpleSharedEvent) {
-    auto my_event = make_shared_event("SomeEvent");
-
-    EXPECT_EQ("SomeEvent", my_event->type().ident_string());
 }

--- a/src/anh/event_dispatcher/event_interface.h
+++ b/src/anh/event_dispatcher/event_interface.h
@@ -35,10 +35,10 @@ public:
 
     virtual const EventType& type() const = 0;
     
-    virtual uint32_t priority() const = 0;
+    virtual uint32_t priority() = 0;
     virtual void priority(uint32_t priority) = 0;
 
-    virtual uint64_t timestamp() const = 0;
+    virtual uint64_t timestamp() = 0;
     virtual void timestamp(uint64_t timestamp) = 0;
 };
 

--- a/src/anh/event_dispatcher/event_interface.h
+++ b/src/anh/event_dispatcher/event_interface.h
@@ -33,7 +33,7 @@ class EventInterface {
 public:
     virtual ~EventInterface() {}
 
-    virtual const EventType& type() = 0;
+    virtual const EventType& type() const = 0;
     
     virtual uint32_t priority() const = 0;
     virtual void priority(uint32_t priority) = 0;

--- a/src/anh/hash_string.cc
+++ b/src/anh/hash_string.cc
@@ -22,14 +22,19 @@
 
 using namespace anh;
 
+HashString::HashString(const std::string &std_string)
+    : ident_(reinterpret_cast<void*>(memcrc(std_string)))
+    , ident_string_(std_string)
+{}
+
 HashString::HashString(const char* ident_string)
     : ident_(reinterpret_cast<void*>(memcrc(std::string(ident_string))))
     , ident_string_(ident_string)
 {}
 
-HashString::HashString(const std::string &std_string)
-    : ident_(reinterpret_cast<void*>(memcrc(std_string)))
-    , ident_string_(std_string)
+HashString::HashString(uint32_t ident)
+    : ident_(reinterpret_cast<void*>(ident))
+    , ident_string_("")
 {}
 
 HashString::~HashString() {}

--- a/src/anh/hash_string.h
+++ b/src/anh/hash_string.h
@@ -35,6 +35,8 @@ public:
     HashString(const std::string& std_string); 
     /// Takes a human readable string and stores a hash of it.
     HashString(const char* ident_string);
+    /// Takes an already hashed value and stores it.
+    HashString(uint32_t ident);
 
     /// Default destructor.
     ~HashString();

--- a/src/api/components/appearance_component_interface.h
+++ b/src/api/components/appearance_component_interface.h
@@ -55,7 +55,7 @@ public:
 class NullAppearanceComponent : AppearanceComponentInterface {
 public:
     NullAppearanceComponent()
-		: AppearanceComponentInterface(0) { }
+		: AppearanceComponentInterface("") { }
     const int race() { return race_; }
     const bool gender() { return gender_; }
     const std::string& model() { return model_; }

--- a/src/api/components/spatial_index_component_interface.h
+++ b/src/api/components/spatial_index_component_interface.h
@@ -60,7 +60,7 @@ public:
 class NullSpatialComponent : SpatialComponentInterface {
 public:
     NullSpatialComponent()
-		: SpatialComponentInterface(0) { }
+		: SpatialComponentInterface("") { }
     std::vector<std::string> regions() { return regions_; }
     const uint16_t spatial_location_id() { return spatial_location_id_; }
     const uint32_t last_updated_ms() { return last_updated_ms_; }


### PR DESCRIPTION
This set of changes makes BasicEvent thread safe and allows events to be made via their hash in addition to strings.
