### PR TITLE
Use tbb scalable allocator when creating shared events

### DIFF
--- a/src/anh/event_dispatcher/basic_event.cc
+++ b/src/anh/event_dispatcher/basic_event.cc
@@ -27,6 +27,10 @@ SimpleEvent anh::event_dispatcher::make_event(EventType type) {
 }
 
 std::shared_ptr<SimpleEvent> anh::event_dispatcher::make_shared_event(EventType type) {
-    auto created_event = std::make_shared<SimpleEvent>(type);
+    auto created_event = std::allocate_shared<SimpleEvent>(
+        tbb::scalable_allocator<SimpleEvent>(), 
+        type
+    );
+
     return created_event;
 }

--- a/src/anh/event_dispatcher/basic_event.h
+++ b/src/anh/event_dispatcher/basic_event.h
@@ -24,6 +24,8 @@
 #include <memory>
 #include <type_traits>
 
+#include <tbb/scalable_allocator.h>
+
 #include "anh/byte_buffer.h"
 #include "anh/hash_string.h"
 #include "anh/event_dispatcher/event_interface.h"
@@ -184,7 +186,12 @@ SimpleEvent make_event(EventType type);
 */
 template<typename T> inline
 std::shared_ptr<BasicEvent<T>> make_shared_event(EventType type, T&& data) {
-    auto created_event = std::make_shared<BasicEvent<T>>(type, std::forward<T>(data));
+    auto created_event = std::allocate_shared<BasicEvent<T>>(
+        tbb::scalable_allocator<BasicEvent<T>>(), 
+        type, 
+        std::forward<T>(data)
+    );
+    
     return created_event;
 }
 

--- a/src/packets/CMakeLists.txt
+++ b/src/packets/CMakeLists.txt
@@ -3,6 +3,8 @@ include(ANHLibrary)
 AddANHLibrary(packets
     DEPENDS 
     	libanh
+	ADDITIONAL_INCLUDE_DIRS
+	    ${TBB_INCLUDE_DIRS}
 	DEBUG_LIBRARIES 
 	    ${TBB_DEBUG_LIBRARIES}
 	OPTIMIZED_LIBRARIES 


### PR DESCRIPTION
Makes use of the tbb scalable allocator for events due to the large number of them being created.
