### PR TITLE
BaseService now stores application kernel

### DIFF
--- a/src/anh/plugin/bindings.h
+++ b/src/anh/plugin/bindings.h
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <string>
 
 #include "anh/app/kernel_interface.h"
@@ -13,7 +14,7 @@ namespace plugin {
     
 struct ObjectParams {
     std::string name;
-    anh::app::KernelInterface* kernel;
+    std::shared_ptr<anh::app::KernelInterface> kernel;
 };
 
 typedef std::function<void * (ObjectParams*)> ObjectCreator;
@@ -26,7 +27,7 @@ struct ObjectRegistration {
 };
 
 typedef void (*ExitFunc)();
-typedef ExitFunc (*InitFunc)(anh::app::KernelInterface&);
+typedef ExitFunc (*InitFunc)(std::shared_ptr<anh::app::KernelInterface>);
 
 #ifdef WIN32
     #ifdef DLL_EXPORTS
@@ -42,7 +43,7 @@ extern
 #ifdef __cplusplus
     "C"
 #endif
-PLUGIN_API ExitFunc InitializePlugin(anh::app::KernelInterface& binding);
+PLUGIN_API ExitFunc InitializePlugin(std::shared_ptr<anh::app::KernelInterface> binding);
 
 }}  // namespace anh::plugin
 

--- a/src/anh/plugin/plugin_manager.cc
+++ b/src/anh/plugin/plugin_manager.cc
@@ -111,7 +111,7 @@ bool PluginManager::InitializePlugin(InitFunc init_func) {
         return false;
     }
 
-    ExitFunc exit_func = init_func(*kernel_);
+    ExitFunc exit_func = init_func(kernel_);
 
     if (!exit_func) {
         return false;

--- a/src/anh/plugin/plugin_manager.h
+++ b/src/anh/plugin/plugin_manager.h
@@ -68,7 +68,7 @@ std::shared_ptr<T> PluginManager::CreateObject(const std::string& name) {
 
         ObjectParams params;
         params.name = name;
-        params.kernel = kernel_.get();
+        params.kernel = kernel_;
 
         object = std::shared_ptr<T>(static_cast<T*>(registration.CreateObject(&params)), registration.DestroyObject);
     }

--- a/src/character/character_service.h
+++ b/src/character/character_service.h
@@ -25,14 +25,18 @@
 
 #include "swganh/base/base_service.h"
 
+namespace anh {
+namespace app {
+class KernelInterface;
+}}  // namespace anh::app
+
 namespace anh { namespace database { class DatabaseManagerInterface; } }
 
 namespace character {
     
 class CharacterService : public swganh::character::BaseCharacterService {
 public:
-    CharacterService(std::shared_ptr<anh::event_dispatcher::EventDispatcherInterface> event_dispatcher,
-                     std::shared_ptr<anh::database::DatabaseManagerInterface> db_manager);
+    explicit CharacterService(std::shared_ptr<anh::app::KernelInterface> kernel);
     ~CharacterService();
 
     void onStart();
@@ -59,7 +63,6 @@ private:
     std::string parseBio_(const std::string& bio);
     std::string parseHair_(const std::string& hair_model, const std::string& hair_customization);
     std::string setCharacterCreateErrorCode_(uint32_t error_id);
-    std::shared_ptr<anh::database::DatabaseManagerInterface> db_manager_;
 };
 
 }  // namespace character

--- a/src/character/main.cc
+++ b/src/character/main.cc
@@ -44,7 +44,7 @@ extern "C" PLUGIN_API void ExitModule() {
     return;
 }
 
-extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
+extern "C" PLUGIN_API ExitFunc InitializePlugin(shared_ptr<KernelInterface> kernel) {
 
     ObjectRegistration registration;
     registration.version.major = 1;
@@ -52,7 +52,7 @@ extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
 
     // Register CreateObject
     registration.CreateObject = [] (ObjectParams* params) -> void * {
-        auto character_service = new CharacterService(params->kernel->GetEventDispatcher(), params->kernel->GetDatabaseManager());
+        auto character_service = new CharacterService(params->kernel);
         return character_service;
     };
 
@@ -62,7 +62,7 @@ extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
         }
     };
 
-    kernel.GetPluginManager()->RegisterObject("CharacterService", &registration);
+    kernel->GetPluginManager()->RegisterObject("CharacterService", &registration);
 
     return ExitModule;
 }

--- a/src/connection/connection_service.cc
+++ b/src/connection/connection_service.cc
@@ -24,6 +24,7 @@
 #include <glog/logging.h>
 
 #include "anh/crc.h"
+#include "anh/app/kernel_interface.h"
 #include "anh/event_dispatcher/basic_event.h"
 #include "anh/event_dispatcher/event_dispatcher_interface.h"
 
@@ -46,6 +47,7 @@
 #include "connection/messages/heart_beat.h"
 
 using namespace anh;
+using namespace app;
 using namespace event_dispatcher;
 using namespace connection;
 using namespace messages;
@@ -54,12 +56,11 @@ using namespace character;
 using namespace scene::messages;
 using namespace std;
 
-ConnectionService::ConnectionService(shared_ptr<EventDispatcherInterface> dispatcher) 
-    : listen_port_(0) {
-
-    event_dispatcher(dispatcher);
+ConnectionService::ConnectionService(shared_ptr<KernelInterface> kernel) 
+    : swganh::base::BaseService(kernel)
+    , listen_port_(0) {
         
-    soe_server_.reset(new network::soe::Server(swganh::base::SwgMessageHandler(dispatcher)));
+    soe_server_.reset(new network::soe::Server(swganh::base::SwgMessageHandler(kernel->GetEventDispatcher())));
 }
 
 ConnectionService::~ConnectionService() {}
@@ -84,12 +85,10 @@ void ConnectionService::onStop() {
 }
 
 void ConnectionService::subscribe() {
-    soe_server_->event_dispatcher(event_dispatcher_);
-    
-    event_dispatcher_->subscribe("CmdSceneReady", bind(&ConnectionService::HandleCmdSceneReady_, this, placeholders::_1));
-    event_dispatcher_->subscribe("ClientIdMsg", bind(&ConnectionService::HandleClientIdMsg_, this, placeholders::_1));
-    event_dispatcher_->subscribe("SelectCharacter", bind(&ConnectionService::HandleSelectCharacter_, this, placeholders::_1));
-    event_dispatcher_->subscribe("ClientCreateCharacter", bind(&ConnectionService::HandleClientCreateCharacter_, this, placeholders::_1));
+    event_dispatcher()->subscribe("CmdSceneReady", bind(&ConnectionService::HandleCmdSceneReady_, this, placeholders::_1));
+    event_dispatcher()->subscribe("ClientIdMsg", bind(&ConnectionService::HandleClientIdMsg_, this, placeholders::_1));
+    event_dispatcher()->subscribe("SelectCharacter", bind(&ConnectionService::HandleSelectCharacter_, this, placeholders::_1));
+    event_dispatcher()->subscribe("ClientCreateCharacter", bind(&ConnectionService::HandleClientCreateCharacter_, this, placeholders::_1));
 }
 
 shared_ptr<CharacterServiceInterface> ConnectionService::character_service() {

--- a/src/connection/connection_service.h
+++ b/src/connection/connection_service.h
@@ -27,6 +27,11 @@
 #include "swganh/character/character_service_interface.h"
 
 namespace anh {
+namespace app {
+class KernelInterface;
+}}  // namespace anh::app
+
+namespace anh {
 namespace event_dispatcher {
 class EventInterface;
 }}  // namespace anh::event_dispatcher
@@ -35,7 +40,7 @@ namespace connection {
     
 class ConnectionService : public swganh::base::BaseService {
 public:
-    explicit ConnectionService(std::shared_ptr<anh::event_dispatcher::EventDispatcherInterface> event_dispatcher);
+    explicit ConnectionService(std::shared_ptr<anh::app::KernelInterface> kernel);
     ~ConnectionService();
     
     void DescribeConfigOptions(boost::program_options::options_description& description);

--- a/src/connection/main.cc
+++ b/src/connection/main.cc
@@ -47,7 +47,7 @@ extern "C" PLUGIN_API void ExitModule() {
     return;
 }
 
-extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
+extern "C" PLUGIN_API ExitFunc InitializePlugin(shared_ptr<KernelInterface> kernel) {
 
     ObjectRegistration registration;
     registration.version.major = 1;
@@ -55,7 +55,7 @@ extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
 
     // Register TestObj
     registration.CreateObject = [] (ObjectParams* params) -> void * {
-        auto connection_service = new ConnectionService(params->kernel->GetEventDispatcher());
+        auto connection_service = new ConnectionService(params->kernel);
         return connection_service;
     };
 
@@ -65,7 +65,7 @@ extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
         }
     };
 
-    kernel.GetPluginManager()->RegisterObject("ConnectionService", &registration);
+    kernel->GetPluginManager()->RegisterObject("ConnectionService", &registration);
 
     return ExitModule;
 }

--- a/src/login/login_service.h
+++ b/src/login/login_service.h
@@ -29,6 +29,11 @@
 #include "swganh/character/base_character_service.h"
 
 namespace anh {
+namespace app {
+class KernelInterface;
+}}  // namespace anh::app
+
+namespace anh {
 namespace network {
 namespace soe {
 class Server;
@@ -56,8 +61,7 @@ class LoginClient;
 
 class LoginService : public swganh::base::BaseService {
 public:
-    explicit LoginService(std::shared_ptr<anh::event_dispatcher::EventDispatcherInterface> event_dispatcher,
-                          std::shared_ptr<anh::database::DatabaseManagerInterface> db_manager);
+    explicit LoginService(std::shared_ptr<anh::app::KernelInterface> kernel);
     ~LoginService();
 
     void DescribeConfigOptions(boost::program_options::options_description& description);

--- a/src/login/main.cc
+++ b/src/login/main.cc
@@ -51,7 +51,7 @@ extern "C" PLUGIN_API void ExitModule() {
     return;
 }
 
-extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
+extern "C" PLUGIN_API ExitFunc InitializePlugin(shared_ptr<KernelInterface> kernel) {
 
     ObjectRegistration registration;
     registration.version.major = 1;
@@ -66,7 +66,7 @@ extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
             return nullptr;
         }
 
-        auto login_service = new LoginService(params->kernel->GetEventDispatcher(), params->kernel->GetDatabaseManager());
+        auto login_service = new LoginService(params->kernel);
         login_service->character_service(character_service);
 
         return login_service;
@@ -78,7 +78,7 @@ extern "C" PLUGIN_API ExitFunc InitializePlugin(KernelInterface& kernel) {
         }
     };
 
-    kernel.GetPluginManager()->RegisterObject("LoginService", &registration);
+    kernel->GetPluginManager()->RegisterObject("LoginService", &registration);
 
     return ExitModule;
 }

--- a/src/swganh/base/base_service.cc
+++ b/src/swganh/base/base_service.cc
@@ -20,14 +20,17 @@
 
 #include "swganh/base/base_service.h"
 
+#include "anh/app/kernel_interface.h"
 #include "anh/event_dispatcher/event_dispatcher_interface.h"
 
 using namespace anh;
+using namespace app;
 using namespace swganh::base;
 using namespace event_dispatcher;
 using namespace std;
 
-BaseService::BaseService() {}
+BaseService::BaseService(shared_ptr<KernelInterface> kernel)
+ : kernel_(kernel) {}
 
 void BaseService::DescribeConfigOptions(boost::program_options::options_description& description) {
 
@@ -48,10 +51,10 @@ void BaseService::Stop() {
 
 bool BaseService::IsRunning() const { return running_; }
 
-shared_ptr<EventDispatcherInterface> BaseService::event_dispatcher() {
-    return event_dispatcher_;
+shared_ptr<KernelInterface> BaseService::kernel() {
+    return kernel_;
 }
 
-void BaseService::event_dispatcher(shared_ptr<EventDispatcherInterface> event_dispatcher) {
-    event_dispatcher_ = event_dispatcher;
+shared_ptr<EventDispatcherInterface> BaseService::event_dispatcher() {
+    return kernel_->GetEventDispatcher();
 }

--- a/src/swganh/base/base_service.h
+++ b/src/swganh/base/base_service.h
@@ -27,6 +27,11 @@
 #include "anh/service/service_interface.h"
 
 namespace anh {
+namespace app {
+class KernelInterface;
+}}  // namespace anh::app
+
+namespace anh {
 namespace event_dispatcher {
 class EventDispatcherInterface;
 }}  // namespace anh::event_dispatcher
@@ -36,18 +41,17 @@ namespace base {
 
 class BaseService : public anh::service::ServiceInterface {
 public:    
-    BaseService();
+    BaseService(std::shared_ptr<anh::app::KernelInterface> kernel);
 
-    virtual void Start();
-    virtual void Stop();
+    void Start();
+    void Stop();
 
-    virtual bool IsRunning() const;
+    bool IsRunning() const;
 
-    virtual void DescribeConfigOptions(boost::program_options::options_description& description);
-    /*
-    *  @brief sets the event_dispatcher
-    */
-    void event_dispatcher(std::shared_ptr<anh::event_dispatcher::EventDispatcherInterface> event_dispatcher);
+    void DescribeConfigOptions(boost::program_options::options_description& description);
+
+    std::shared_ptr<anh::app::KernelInterface> kernel();
+
     /*
     *  @brief used to subscribe to events on a serivce
     */
@@ -60,15 +64,17 @@ public:
     *  @brief used to perform any shutdown specific tasks for the service
     */
     virtual void onStop() = 0;
+
     /*
     *  @brief gets the event_dispatcher
     */
     std::shared_ptr<anh::event_dispatcher::EventDispatcherInterface> event_dispatcher();
     
 
-protected:
-    std::shared_ptr<anh::event_dispatcher::EventDispatcherInterface> event_dispatcher_;
-    
+private:
+    BaseService();
+    std::shared_ptr<anh::app::KernelInterface> kernel_;
+        
     tbb::atomic<bool> running_;
 };
 

--- a/src/swganh/character/base_character_service.h
+++ b/src/swganh/character/base_character_service.h
@@ -29,17 +29,28 @@
 #include "swganh/character/character_data.h"
 #include "connection/messages/client_create_character.h"
 
+namespace anh {
+namespace app {
+class KernelInterface;
+}}  // namespace anh::app
+
 namespace swganh {
 namespace character {
     
 class BaseCharacterService : public swganh::base::BaseService {
 public:    
+    BaseCharacterService(std::shared_ptr<anh::app::KernelInterface> kernel) 
+        : swganh::base::BaseService(kernel) {}
+
     virtual std::vector<CharacterData> GetCharactersForAccount(uint64_t account_id) = 0;
     virtual CharacterLoginData GetLoginCharacter(uint64_t character_id) = 0;
     virtual bool DeleteCharacter(uint64_t character_id) = 0;
     virtual std::wstring GetRandomNameRequest(const std::string& base_model) = 0;
     virtual bool UpdateCharacterStatus(uint64_t character_id, uint32_t status) = 0;
     virtual std::tuple<uint64_t, std::string> CreateCharacter(const connection::messages::ClientCreateCharacter& character_info) = 0;
+
+private:
+    BaseCharacterService();
 };
 
 }}  // namespace swganh::character


### PR DESCRIPTION
The BaseService now takes an instance of the KernelInterface that currently holds all the application's core functionality.

This gives each service optional access to all the low level application functionality such as event dispatching, network management, database management, etc.
