### PR TITLE
Login service now sends galaxy status updates

### DIFF
--- a/data/config/swganh.cfg
+++ b/data/config/swganh.cfg
@@ -14,13 +14,14 @@ password = swganh
 
 [db.galaxy]
 host = localhost
-schema = naritus
+schema = galaxy
 username = swganh
 password = swganh
 
 [service.login]
 udp_port = 44453
 address = 127.0.0.1
+status_check_duration_secs = 30
 
 [service.connection]
 udp_port = 44463

--- a/src/anh/app/kernel_interface.h
+++ b/src/anh/app/kernel_interface.h
@@ -6,6 +6,8 @@
 #include <memory>
 #include <string>
 
+#include <boost/asio/io_service.hpp>
+
 namespace anh {
 namespace database {
 class DatabaseManagerInterface;
@@ -51,6 +53,8 @@ public:
     virtual std::shared_ptr<anh::service::ServiceManager> GetServiceManager() = 0;
 
     virtual std::shared_ptr<anh::database::DatabaseManagerInterface> GetDatabaseManager() = 0;
+
+    virtual boost::asio::io_service& GetIoService() = 0;
 
     // also add entity manager, blah blah.
 };

--- a/src/login/login_service.h
+++ b/src/login/login_service.h
@@ -23,6 +23,8 @@
 
 #include <map>
 
+#include <boost/asio.hpp>
+
 #include "anh/network/soe/server.h"
 
 #include "swganh/base/base_service.h"
@@ -95,9 +97,11 @@ private:
 
     bool HandleLoginClientId_(std::shared_ptr<anh::event_dispatcher::EventInterface> incoming_event);
     bool HandleDeleteCharacterMessage_(std::shared_ptr<anh::event_dispatcher::EventInterface> incoming_event);
+    bool HandleGalaxyStatusUpdated_(std::shared_ptr<anh::event_dispatcher::EventInterface> incoming_event);
 
     std::vector<GalaxyStatus> GetGalaxyStatus_();
-    
+    void UpdateGalaxyStatus_();
+
     void SendLoginClientToken_(std::shared_ptr<LoginClient> login_client);
     void SendLoginEnumCluster_(std::shared_ptr<LoginClient> login_client);
     void SendLoginClusterStatus_(std::shared_ptr<LoginClient> login_client);
@@ -109,6 +113,9 @@ private:
     std::shared_ptr<providers::AccountProviderInterface> account_provider_;
 
     std::vector<GalaxyStatus> galaxy_status_;
+    
+    int galaxy_status_check_duration_secs_;
+    boost::asio::deadline_timer galaxy_status_timer_;
 
     typedef std::map<uint32_t, std::shared_ptr<LoginClient>> ClientMap;
     ClientMap clients_;

--- a/src/swganh/app/swganh_app.cc
+++ b/src/swganh/app/swganh_app.cc
@@ -112,6 +112,7 @@ void SwganhApp::Start() {
 
     do {
         kernel_->GetEventDispatcher()->tick();
+        kernel_->GetIoService().poll();
         kernel_->GetServiceManager()->Update();
     } while(IsRunning());
 }

--- a/src/swganh/app/swganh_app.cc
+++ b/src/swganh/app/swganh_app.cc
@@ -91,6 +91,8 @@ void SwganhApp::Initialize(int argc, char* argv[]) {
     auto data_store = make_shared<service::Datastore>(kernel_->GetDatabaseManager()->getConnection("galaxy_manager"));
     service_directory_ = make_shared<service::ServiceDirectory>(data_store, kernel_->GetEventDispatcher(), app_config.galaxy_name, kernel_->GetVersion().ToString(), true);
     
+    CleanupServices_();
+
     // Load the plugin configuration.
     LoadPlugins_(app_config.plugins);
 
@@ -187,4 +189,18 @@ void SwganhApp::LoadPlugins_(vector<string> plugins) {
             plugin_manager->LoadPlugin(plugin);
         });
     }
+}
+
+void SwganhApp::CleanupServices_() {
+    auto services = service_directory_->getServiceSnapshot(service_directory_->galaxy());
+
+    if (services.empty()) {
+        return;
+    }
+
+    DLOG(WARNING) << "Services were not shutdown properly";
+
+    for_each(services.begin(), services.end(), [this] (anh::service::Service& service) {
+        service_directory_->removeService(make_shared<anh::service::Service>(service));
+    });
 }

--- a/src/swganh/app/swganh_app.h
+++ b/src/swganh/app/swganh_app.h
@@ -44,6 +44,8 @@ private:
     void LoadAppConfig_(int argc, char* argv[]);
     void LoadServiceConfig_(ServiceConfig& service_config);
     void LoadPlugins_(std::vector<std::string> plugins);
+
+    void CleanupServices_();
     
     std::shared_ptr<SwganhKernel> kernel_;
     std::shared_ptr<anh::service::ServiceDirectory> service_directory_;

--- a/src/swganh/app/swganh_kernel.cc
+++ b/src/swganh/app/swganh_kernel.cc
@@ -73,3 +73,8 @@ shared_ptr<ServiceManager> SwganhKernel::GetServiceManager() {
 
     return service_manager_;
 }
+
+boost::asio::io_service& SwganhKernel::GetIoService() {
+    return io_service_;
+}
+

--- a/src/swganh/app/swganh_kernel.h
+++ b/src/swganh/app/swganh_kernel.h
@@ -49,6 +49,8 @@ public:
     std::shared_ptr<anh::plugin::PluginManager> GetPluginManager();
 
     std::shared_ptr<anh::service::ServiceManager> GetServiceManager();
+    
+    boost::asio::io_service& GetIoService();
 
 private:
     anh::app::Version version_;
@@ -58,6 +60,8 @@ private:
     std::shared_ptr<anh::event_dispatcher::EventDispatcherInterface> event_dispatcher_;
     std::shared_ptr<anh::plugin::PluginManager> plugin_manager_;
     std::shared_ptr<anh::service::ServiceManager> service_manager_;
+
+    boost::asio::io_service io_service_;
 };
 
 }}  // namespace anh::app

--- a/src/swganh/base/base_service.cc
+++ b/src/swganh/base/base_service.cc
@@ -82,3 +82,7 @@ shared_ptr<KernelInterface> BaseService::kernel() {
 shared_ptr<service::ServiceDirectory> BaseService::service_directory() {
     return service_directory_;
 }
+
+boost::asio::strand& BaseService::strand() {
+    return strand_;
+}

--- a/src/swganh/base/base_service.cc
+++ b/src/swganh/base/base_service.cc
@@ -36,7 +36,8 @@ using namespace event_dispatcher;
 using namespace std;
 
 BaseService::BaseService(shared_ptr<KernelInterface> kernel)
- : kernel_(kernel) {
+ : kernel_(kernel)
+ , strand_(kernel->GetIoService()) {
     auto data_store = make_shared<service::Datastore>(kernel->GetDatabaseManager()->getConnection("galaxy_manager"));
     service_directory_ = make_shared<service::ServiceDirectory>(data_store, kernel->GetEventDispatcher());
 

--- a/src/swganh/base/base_service.h
+++ b/src/swganh/base/base_service.h
@@ -53,7 +53,8 @@ public:
     void Update();
 
     bool IsRunning() const;
-
+        
+protected:
     std::shared_ptr<anh::app::KernelInterface> kernel();
     std::shared_ptr<anh::service::ServiceDirectory> service_directory();
 
@@ -72,7 +73,6 @@ public:
     *  @brief used to perform any shutdown specific tasks for the service
     */
     virtual void onStop() = 0;
-    
 
 private:
     BaseService();

--- a/src/swganh/base/base_service.h
+++ b/src/swganh/base/base_service.h
@@ -23,6 +23,8 @@
 
 #include <memory>
 #include <string>
+
+#include <boost/asio.hpp>
 #include <tbb/atomic.h>
 
 #include "anh/service/service_directory.h"
@@ -58,6 +60,8 @@ protected:
     std::shared_ptr<anh::app::KernelInterface> kernel();
     std::shared_ptr<anh::service::ServiceDirectory> service_directory();
 
+    boost::asio::strand& strand();
+
     /*
     *  @brief used to subscribe to events on a serivce
     */
@@ -82,6 +86,8 @@ private:
     tbb::atomic<bool> running_;
 
     std::string galaxy_name_;
+
+    boost::asio::strand strand_;
 };
 
 }}  // swganh::base


### PR DESCRIPTION
Added a new configuration option for login service that determines the interval between galaxy status updates.

Triggers a GalaxyStatusUpdated event whenever the status check completes.

A listener for GalaxyStatusUpdated sends updates to all connected clients.
