### PR TITLE
Now displays the proper error message when logging in with faulty credent

### DIFF
--- a/src/anh/utils/active_object.h
+++ b/src/anh/utils/active_object.h
@@ -51,8 +51,10 @@ public:
     void SendDelayed(boost::posix_time::time_duration period, Handler message) {
         auto timer = std::make_shared<boost::asio::deadline_timer>(io_service_);
         
-        timer_->expires_from_now(period);
-        timer_->async_wait(strand_.wrap(message));
+        timer->expires_from_now(period);
+        timer->async_wait(strand_.wrap([timer, message] (const boost::system::error_code& error) {
+            message(error);   
+        }));
     }
     
     /**

--- a/src/login/login_service.h
+++ b/src/login/login_service.h
@@ -95,6 +95,7 @@ private:
     std::vector<GalaxyStatus> galaxy_status_;
     
     int galaxy_status_check_duration_secs_;
+    int login_error_timeout_secs_;
     boost::asio::deadline_timer galaxy_status_timer_;
 
     typedef std::map<boost::asio::ip::udp::endpoint, std::shared_ptr<LoginClient>> ClientMap;

--- a/src/login/messages/error_message.h
+++ b/src/login/messages/error_message.h
@@ -1,0 +1,54 @@
+/*
+ This file is part of MMOServer. For more information, visit http://swganh.com
+ 
+ Copyright (c) 2006 - 2010 The SWG:ANH Team
+
+ MMOServer is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ MMOServer is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with MMOServer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef LOGIN_MESSAGES_ERROR_MESSAGE_H_
+#define LOGIN_MESSAGES_ERROR_MESSAGE_H_
+
+#include <cstdint>
+#include <string>
+#include "anh/byte_buffer.h"
+#include "swganh/base/swg_message.h"
+
+namespace login {
+namespace messages {
+    
+struct ErrorMessage : public swganh::base::SwgMessage<ErrorMessage> {
+    static const uint16_t opcount = 3;
+    static const uint32_t opcode = 0xB5ABF91A;
+    
+    std::string type;
+    std::string message;
+    bool force_fatal;
+    
+    void onSerialize(anh::ByteBuffer& buffer) const {
+        buffer.write(type);
+        buffer.write(message);
+        buffer.write(force_fatal);
+    }
+    
+    void onDeserialize(anh::ByteBuffer buffer) {
+        type = buffer.read<std::string>();
+        message = buffer.read<std::string>();
+        force_fatal = buffer.read<bool>();
+    }    
+};
+
+}}  // namespace login::messages
+
+#endif  // LOGIN_MESSAGES_ERROR_MESSAGE_H_


### PR DESCRIPTION
Now displays the proper error message when logging in with faulty credentials.

fixes #54
