### PR TITLE
Added in automatic updating of Galaxy Status through each individual serv

### DIFF
--- a/src/anh/service/datastore.cc
+++ b/src/anh/service/datastore.cc
@@ -31,7 +31,6 @@
 #include <cppconn/prepared_statement.h>
 #include <cppconn/resultset.h>
 
-#include "anh/service/galaxy.h"
 #include "anh/service/service_description.h"
 
 using namespace anh::service;
@@ -118,6 +117,23 @@ std::shared_ptr<Galaxy> Datastore::createGalaxy(
     }
 
     return galaxy;
+}
+void Datastore::saveGalaxyStatus(int32_t galaxy_id, int32_t status) const
+{
+    try {
+        std::unique_ptr<sql::PreparedStatement> statement(connection_->prepareStatement(
+            "update galaxy set status = ? "
+            "where id = ?"));
+
+        statement->setInt(1, status);
+        statement->setInt(2, galaxy_id);
+
+        statement->executeUpdate();
+
+    } catch(sql::SQLException &e) {
+        DLOG(ERROR) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
+        DLOG(ERROR) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
+    }
 }
 
 std::shared_ptr<ServiceDescription> Datastore::createService(std::shared_ptr<Galaxy> galaxy, const std::string& name, const std::string& type, const std::string& version, const std::string& address, uint16_t tcp_port, uint16_t udp_port, uint16_t ping_port) const {

--- a/src/anh/service/datastore.h
+++ b/src/anh/service/datastore.h
@@ -29,6 +29,7 @@
 #include <boost/noncopyable.hpp>
 
 #include "anh/service/datastore_interface.h"
+#include "anh/service/galaxy.h"
 
 namespace sql {
     class Connection; 
@@ -37,7 +38,6 @@ namespace sql {
 namespace anh {
 namespace service {
 
-class Galaxy;
 class ServiceDescription;
 
 class Datastore : public DatastoreInterface , boost::noncopyable {
@@ -50,6 +50,7 @@ public:
     std::shared_ptr<Galaxy> createGalaxy(const std::string& name, const std::string& version) const;
     std::shared_ptr<Galaxy> findGalaxyById(uint32_t id) const;
     std::shared_ptr<Galaxy> findGalaxyByName(const std::string& name) const;
+    void saveGalaxyStatus(int32_t galaxy_id, int32_t status) const;
     
     std::shared_ptr<ServiceDescription> createService(std::shared_ptr<Galaxy> galaxy, const std::string& name, const std::string& type, const std::string& version, const std::string& address, uint16_t tcp_port, uint16_t udp_port, uint16_t ping_port) const;
     std::shared_ptr<ServiceDescription> findServiceById(uint32_t id) const;

--- a/src/anh/service/datastore_interface.h
+++ b/src/anh/service/datastore_interface.h
@@ -41,6 +41,7 @@ public:
     virtual std::shared_ptr<ServiceDescription> createService(std::shared_ptr<Galaxy> galaxy, const std::string& name, const std::string& type, const std::string& version, const std::string& address, uint16_t tcp_port, uint16_t udp_port, uint16_t ping_port) const = 0;
 
     virtual std::string getGalaxyTimestamp(std::shared_ptr<Galaxy> galaxy) const = 0;
+    virtual void saveGalaxyStatus(int32_t galaxy_id, int32_t status) const = 0;
 
     virtual void saveService(std::shared_ptr<ServiceDescription> service) const = 0;
 

--- a/src/anh/service/galaxy.cc
+++ b/src/anh/service/galaxy.cc
@@ -97,6 +97,10 @@ Galaxy::StatusType Galaxy::status() const {
     return status_;
 }
 
+void Galaxy::status(Galaxy::StatusType status) {
+    status_ = status;
+}
+
 const std::string& Galaxy::created_at() const {
     return created_at_;
 }

--- a/src/anh/service/galaxy.h
+++ b/src/anh/service/galaxy.h
@@ -94,7 +94,12 @@ public:
     *
     * \returns Returns the current status of the galaxy.
     */
-    Galaxy::StatusType status() const;    
+    Galaxy::StatusType status() const;  
+
+    /*! sets the current status of the galaxy.
+    *
+    */
+    void status(Galaxy::StatusType status);
     
     /*! Returns the timestamp indicating the time the galaxy was first created.
     *

--- a/src/anh/service/mock_service_directory.h
+++ b/src/anh/service/mock_service_directory.h
@@ -46,6 +46,7 @@ public:
         int32_t new_status));
     MOCK_METHOD1(makePrimaryService, bool(std::shared_ptr<ServiceDescription> service));
     MOCK_METHOD0(pulse, void());
+    MOCK_METHOD0(updateGalaxyStatus, void());
     MOCK_CONST_METHOD0(galaxy, std::shared_ptr<Galaxy>());
     MOCK_CONST_METHOD0(service, std::shared_ptr<ServiceDescription>());
     MOCK_CONST_METHOD0(getGalaxySnapshot, GalaxyList());

--- a/src/anh/service/service_directory.h
+++ b/src/anh/service/service_directory.h
@@ -65,6 +65,8 @@ public:
     std::shared_ptr<ServiceDescription> service() const;
         
     void joinGalaxy(const std::string& galaxy_name, const std::string& version = "", bool create_galaxy = false);
+    
+    void updateGalaxyStatus();
 
     bool registerService(const std::string& name, const std::string& service_type, const std::string& version, const std::string& address, uint16_t tcp_port, uint16_t udp_port, uint16_t ping);
     bool removeService(std::shared_ptr<ServiceDescription>& service);
@@ -73,7 +75,7 @@ public:
     bool makePrimaryService(std::shared_ptr<ServiceDescription> service);
 
     void pulse();
-
+    
     GalaxyList getGalaxySnapshot() const;
     ServiceList getServiceSnapshot(std::shared_ptr<Galaxy> galaxy) const;
 

--- a/src/anh/service/service_directory_interface.h
+++ b/src/anh/service/service_directory_interface.h
@@ -42,6 +42,8 @@ public:
 
     virtual void joinGalaxy(const std::string& galaxy_name, const std::string& version = "", bool create_galaxy = false) = 0;
 
+    virtual void updateGalaxyStatus() = 0;
+
     virtual bool registerService(
         const std::string& name, 
         const std::string& service_type, 

--- a/src/anh/service/service_directory_unittest.cc
+++ b/src/anh/service/service_directory_unittest.cc
@@ -67,6 +67,7 @@ public:
     MOCK_CONST_METHOD8(createService, shared_ptr<ServiceDescription>(std::shared_ptr<Galaxy> galaxy, const std::string& name, const std::string& type, const std::string& version, const std::string& address, uint16_t tcp_port, uint16_t udp_port, uint16_t ping_port));
     MOCK_CONST_METHOD1(getGalaxyTimestamp, std::string(std::shared_ptr<Galaxy> galaxy));
     MOCK_CONST_METHOD1(saveService, void(std::shared_ptr<ServiceDescription> service));
+    MOCK_CONST_METHOD2(saveGalaxyStatus ,void(int32_t galaxy_id, int32_t status));
     MOCK_CONST_METHOD1(findGalaxyById, shared_ptr<Galaxy>(uint32_t id));
     MOCK_CONST_METHOD1(deleteServiceById, bool(uint32_t id));
     MOCK_CONST_METHOD0(getGalaxyList, GalaxyList());
@@ -216,7 +217,7 @@ TEST_F(ServiceDirectoryTest, PulsingUpdatesActiveServiceTimestamp) {
     
     EXPECT_CALL(*datastore, findGalaxyById(test_galaxy_->id()))
         .WillOnce(Return(test_galaxy_));
-
+       
     try {
         ServiceDirectory service_directory(datastore, dispatcher_, "test_galaxy", "20050408-18:00");
 

--- a/src/login/login_service.cc
+++ b/src/login/login_service.cc
@@ -206,12 +206,16 @@ std::vector<GalaxyStatus> LoginService::GetGalaxyStatus_() {
             GalaxyStatus status;
             status.address = it->address();
             status.connection_port = it->udp_port();
+            // TODO: Add a meaningful value here (ping to client from server?)
             status.distance = 0xffff8f80;
             status.galaxy_id = galaxy.id();
+            // TODO: Add a configurable value here
             status.max_characters = 2;
+            // TODO: Add a configurable value here
             status.max_population = 0x00000cb2;
             status.name = galaxy.name();
             status.ping_port = it->ping_port();
+            // TODO: Keep track of people logged in to server and update to db
             status.server_population = 10;
             status.status = service_directory->galaxy()->status();
 

--- a/src/swganh/app/swganh_app.cc
+++ b/src/swganh/app/swganh_app.cc
@@ -101,6 +101,7 @@ void SwganhApp::Initialize(int argc, char* argv[]) {
 
     LoadServiceConfig_(service_config_);
 
+    
     initialized_ = true;
 }
 
@@ -119,9 +120,8 @@ void SwganhApp::Start() {
         auto t = make_shared<boost::thread>(bind(&boost::asio::io_service::run, &kernel_->GetIoService()));
         io_threads_.push_back(t);
     }
-
     kernel_->GetServiceManager()->Start();
-
+    
     do {
         kernel_->GetEventDispatcher()->tick();
     } while(IsRunning());


### PR DESCRIPTION
Added in automatic updating of Galaxy Status through each individual service Status. This makes it so the server wont show as "Online" until all services have been completely started.
