### PR TITLE
Renamed SendDelayed and SendRepeated to Async variants.

### DIFF
--- a/src/anh/network/soe/server.cc
+++ b/src/anh/network/soe/server.cc
@@ -82,13 +82,11 @@ void Server::Start(uint16_t port)
         make_filter<shared_ptr<Packet>, shared_ptr<Packet>>(filter::parallel, CrcOutFilter()) &
         make_filter<shared_ptr<Packet>, void>(filter::serial_in_order, SendPacketFilter(socket_));
 
-    active_.SendRepeated(boost::posix_time::milliseconds(1), [this] (const boost::system::error_code& error) {
-        if (!error) {
-            parallel_pipeline(1000, incoming_filter_);
-            parallel_pipeline(1000, outgoing_filter_);
+    active_.AsyncRepeated(boost::posix_time::milliseconds(1), [this] () {
+        parallel_pipeline(1000, incoming_filter_);
+        parallel_pipeline(1000, outgoing_filter_);
 
-            session_manager_.Update();
-        }
+        session_manager_.Update();
     });
 }
 

--- a/src/anh/utils/timing.h
+++ b/src/anh/utils/timing.h
@@ -36,15 +36,6 @@ private:
     Handler handler_;
 };
 
-template<typename Handler>
-void AsyncRepeat(std::shared_ptr<boost::asio::deadline_timer> timer,
-    boost::posix_time::time_duration period,
-    Handler handler)
-{
-    timer->expires_from_now(period);
-    timer->async_wait(RepeatHandler<Handler>(timer, period, handler));
-}
-
 }}  // namespace anh::utils
 
 #endif  // ANH_UTILS_TIMING_H_

--- a/src/swganh/base/base_service.cc
+++ b/src/swganh/base/base_service.cc
@@ -62,24 +62,18 @@ void BaseService::Start() {
         }
 
         auto service_directory = service_directory_;
-
-        // @TODO: Change this time to a value based on the timeout for services in the service directory's watchdog operations.
-        active_.SendRepeated(boost::posix_time::seconds(3), [service_directory] (const boost::system::error_code& error) {
-            if (!error) {
-                service_directory->pulse();
-            }
-        });
+        
         // update the status of the service
         service_directory_->updateServiceStatus(service_directory_->service(), anh::service::Galaxy::ONLINE);
 
-        active_.Async([service_directory] () {
-            service_directory->updateGalaxyStatus();
+        // @TODO: Change this time to a value based on the timeout for services in the service directory's watchdog operations.
+        active_.AsyncRepeated(boost::posix_time::seconds(3), [service_directory] () {
+            service_directory->pulse();
         });
+        
         // @TODO: change this time to a value based on the timeout for galaxy
-        active_.SendRepeated(boost::posix_time::seconds(30), [service_directory] (const boost::system::error_code& error) {
-             if (!error) {
-                service_directory->updateGalaxyStatus();
-             }
+        active_.AsyncRepeated(boost::posix_time::seconds(30), [service_directory] () {
+            service_directory->updateGalaxyStatus();
         });
 
         onStart();


### PR DESCRIPTION
AsyncRepeated now "immediately" calls the passed handler in addition to rescheduling it for future calls.

Updated usages of both member functions.
