### PR TITLE
Part 2 of the connection server refactoring

### DIFF
--- a/src/anh/network/soe/session.cc
+++ b/src/anh/network/soe/session.cc
@@ -268,9 +268,13 @@ void Session::handleChildDataA_(ChildDataA& packet)
     AcknowledgeSequence_(packet.sequence);
 
     std::for_each(packet.messages.begin(), packet.messages.end(), [this] (shared_ptr<ByteBuffer> message) {
-        auto packet = make_shared<Packet>(shared_from_this(), message);
+        try {
+            auto packet = make_shared<Packet>(shared_from_this(), message);
 
-        this->server_->HandleMessage(packet);
+            this->server_->HandleMessage(packet);
+        } catch(...) {
+
+        }
     });
 }
 

--- a/src/character/character_service.h
+++ b/src/character/character_service.h
@@ -26,6 +26,7 @@
 #include "swganh/base/base_service.h"
 
 #include "swganh/character/messages/select_character.h"
+#include "swganh/character/messages/delete_character_message.h"
 #include "swganh/character/messages/client_create_character.h"
 #include "swganh/character/messages/client_create_character_success.h"
 #include "swganh/character/messages/client_create_character_failed.h"
@@ -43,6 +44,11 @@ namespace swganh {
 namespace connection {
 struct ConnectionClient;
 }}  // namespace swganh::connection
+
+namespace swganh {
+namespace login {
+struct LoginClient;
+}}  // namespace swganh::login
 
 namespace character {
     
@@ -72,7 +78,10 @@ private:
     void HandleSelectCharacter_(std::shared_ptr<swganh::connection::ConnectionClient> client, const swganh::character::messages::SelectCharacter& message);
     void HandleClientRandomNameRequest_(std::shared_ptr<swganh::connection::ConnectionClient> client, const swganh::character::messages::ClientRandomNameRequest& message);
     void HandleClientCreateCharacter_(std::shared_ptr<swganh::connection::ConnectionClient> client, const swganh::character::messages::ClientCreateCharacter& message);
-    
+    void HandleDeleteCharacterMessage_(
+        std::shared_ptr<swganh::login::LoginClient> login_client, 
+        const swganh::character::messages::DeleteCharacterMessage& message);
+
     // helpers
     std::string parseBio_(const std::string& bio);
     std::string parseHair_(const std::string& hair_model, const std::string& hair_customization);

--- a/src/connection/connection_service.h
+++ b/src/connection/connection_service.h
@@ -29,7 +29,6 @@
 #include "connection/providers/session_provider_interface.h"
 #include "swganh/base/base_service.h"
 #include "swganh/character/base_character_service.h"
-#include "swganh/login/login_service_interface.h"
 
 #include "swganh/scene/messages/cmd_scene_ready.h"
 

--- a/src/connection/main.cc
+++ b/src/connection/main.cc
@@ -31,9 +31,6 @@
 #include "anh/plugin/plugin_manager.h"
 #include "anh/service/service_manager.h"
 
-#include "swganh/character/base_character_service.h"
-#include "swganh/login/login_service_interface.h"
-
 #include "connection/connection_service.h"
 
 using namespace anh;

--- a/src/login/authentication_manager.cc
+++ b/src/login/authentication_manager.cc
@@ -20,10 +20,11 @@
 
 #include "login/authentication_manager.h"
 
-#include "login/account.h"
-#include "login/login_client.h"
+#include "swganh/login/account.h"
+#include "swganh/login/login_client.h"
 
 using namespace login;
+using namespace swganh::login;
 using namespace std;
 
 AuthenticationManager::AuthenticationManager(std::shared_ptr<encoders::EncoderInterface> encoder) 

--- a/src/login/authentication_manager.h
+++ b/src/login/authentication_manager.h
@@ -25,10 +25,13 @@
 
 #include "encoders/encoder_interface.h"
 
+namespace swganh {
 namespace login {
-
 class Account;
 struct LoginClient;
+}}  // namespace swganh::login
+
+namespace login {
 
 class AuthenticationManager {
 public:
@@ -36,7 +39,9 @@ public:
 
     std::shared_ptr<encoders::EncoderInterface> encoder();
 
-    bool Authenticate(std::shared_ptr<LoginClient> client, std::shared_ptr<Account> account);
+    bool Authenticate(
+        std::shared_ptr<swganh::login::LoginClient> client, 
+        std::shared_ptr<swganh::login::Account> account);
 
 private:
     std::shared_ptr<encoders::EncoderInterface> encoder_;

--- a/src/login/login_service.h
+++ b/src/login/login_service.h
@@ -21,7 +21,7 @@
 #ifndef LOGIN_LOGIN_SERVICE_H_
 #define LOGIN_LOGIN_SERVICE_H_
 
-#include "swganh/login/login_service_interface.h"
+#include "swganh/login/base_login_service.h"
 
 #include <boost/asio.hpp>
 #include <glog/logging.h>
@@ -30,12 +30,12 @@
 #include "anh/network/soe/packet_utilities.h"
 #include "anh/network/soe/server.h"
 
-#include "swganh/base/swg_message_router.h"
 #include "swganh/character/base_character_service.h"
+
+#include "swganh/login/login_client.h"
 
 #include "login/galaxy_status.h"
 #include "login/messages/login_client_id.h"
-#include "login/messages/delete_character_message.h"
 
 namespace anh {
 namespace network {
@@ -61,16 +61,13 @@ namespace providers {
 class AccountProviderInterface;
 }
 
-struct LoginClient;
-
 class LoginService 
-    : public swganh::login::LoginServiceInterface
-    , public swganh::base::SwgMessageRouter<LoginClient> 
+    : public swganh::login::BaseLoginService
 {
 public:
     typedef tbb::concurrent_hash_map<
         boost::asio::ip::udp::endpoint, 
-        std::shared_ptr<LoginClient>,
+        std::shared_ptr<swganh::login::LoginClient>,
         anh::network::soe::EndpointHashCompare
     > ClientMap;
 
@@ -82,7 +79,7 @@ public:
     void DescribeConfigOptions(boost::program_options::options_description& description);
     uint32_t GetAccountBySessionKey(const std::string& session_key);
         
-    std::shared_ptr<LoginClient> GetClientFromEndpoint(
+    std::shared_ptr<swganh::login::LoginClient> GetClientFromEndpoint(
         const boost::asio::ip::udp::endpoint& remote_endpoint);
 private:
     LoginService();
@@ -92,11 +89,10 @@ private:
 
     void subscribe();
     
-    void HandleLoginClientId_(std::shared_ptr<LoginClient> login_client, const messages::LoginClientId& message);
-    void HandleDeleteCharacterMessage_(std::shared_ptr<LoginClient> login_client, const messages::DeleteCharacterMessage& message);
+    void HandleLoginClientId_(std::shared_ptr<swganh::login::LoginClient> login_client, const messages::LoginClientId& message);
 
     void RemoveClient_(std::shared_ptr<anh::network::soe::Session> session);
-    std::shared_ptr<LoginClient> AddClient_(std::shared_ptr<anh::network::soe::Session> session);
+    std::shared_ptr<swganh::login::LoginClient> AddClient_(std::shared_ptr<anh::network::soe::Session> session);
 
     std::vector<GalaxyStatus> GetGalaxyStatus_();
     void UpdateGalaxyStatus_();

--- a/src/login/messages/login_client_token.cc
+++ b/src/login/messages/login_client_token.cc
@@ -1,7 +1,7 @@
 #include "login/messages/login_client_token.h"
 
-#include "login/login_client.h"
-#include "login/account.h"
+#include "swganh/login/login_client.h"
+#include "swganh/login/account.h"
 
 using namespace login;
 using namespace messages;
@@ -9,7 +9,7 @@ using namespace std;
 
 using anh::ByteBuffer;
 
-LoginClientToken login::messages::BuildLoginClientToken(shared_ptr<LoginClient> login_client, const std::string& session_key) {
+LoginClientToken login::messages::BuildLoginClientToken(shared_ptr<swganh::login::LoginClient> login_client, const std::string& session_key) {
     LoginClientToken message;
 
     ByteBuffer session_buffer;

--- a/src/login/messages/login_client_token.h
+++ b/src/login/messages/login_client_token.h
@@ -26,9 +26,10 @@
 #include "anh/byte_buffer.h"
 #include "swganh/base/swg_message.h"
 
+namespace swganh {
 namespace login {
 struct LoginClient;
-}  // namespace login
+}}  // namespace swganh::login
 
 namespace login {
 namespace messages {
@@ -57,7 +58,7 @@ struct LoginClientToken : public swganh::base::SwgMessage<LoginClientToken> {
     }
 };
 
-LoginClientToken BuildLoginClientToken(std::shared_ptr<login::LoginClient> login_client, const std::string& session_key);
+LoginClientToken BuildLoginClientToken(std::shared_ptr<swganh::login::LoginClient> login_client, const std::string& session_key);
 
 }}  // namespace login::messages
 

--- a/src/login/messages/login_cluster_status.cc
+++ b/src/login/messages/login_cluster_status.cc
@@ -1,7 +1,5 @@
 #include "login/messages/login_cluster_status.h"
 
-#include "login/login_client.h"
-
 using namespace login;
 using namespace messages;
 using namespace std;

--- a/src/login/messages/login_cluster_status.h
+++ b/src/login/messages/login_cluster_status.h
@@ -32,10 +32,6 @@
 #include "login/galaxy_status.h"
 
 namespace login {
-struct LoginClient;
-}  // namespace login
-
-namespace login {
 namespace messages {
 
 struct ClusterServer {

--- a/src/login/messages/login_enum_cluster.cc
+++ b/src/login/messages/login_enum_cluster.cc
@@ -1,12 +1,12 @@
 #include "login/messages/login_enum_cluster.h"
 
-#include "login/login_client.h"
+#include "swganh/login/login_client.h"
 
 using namespace login;
 using namespace messages;
 using namespace std;
 
-LoginEnumCluster login::messages::BuildLoginEnumCluster(shared_ptr<LoginClient> login_client, const vector<GalaxyStatus>& galaxy_status) {
+LoginEnumCluster login::messages::BuildLoginEnumCluster(shared_ptr<swganh::login::LoginClient> login_client, const vector<GalaxyStatus>& galaxy_status) {
     LoginEnumCluster message;
     message.max_account_chars = 2;
 

--- a/src/login/messages/login_enum_cluster.h
+++ b/src/login/messages/login_enum_cluster.h
@@ -32,9 +32,10 @@
 
 #include "login/galaxy_status.h"
 
+namespace swganh {
 namespace login {
 struct LoginClient;
-}  // namespace login
+}}  // namespace swganh::login
 
 namespace login {
 namespace messages {
@@ -77,7 +78,7 @@ struct LoginEnumCluster : public swganh::base::SwgMessage<LoginEnumCluster> {
     }
 };
 
-LoginEnumCluster BuildLoginEnumCluster(std::shared_ptr<login::LoginClient> login_client, const std::vector<login::GalaxyStatus>& galaxy_status);
+LoginEnumCluster BuildLoginEnumCluster(std::shared_ptr<swganh::login::LoginClient> login_client, const std::vector<login::GalaxyStatus>& galaxy_status);
 
 }}  // namespace login::messages
 

--- a/src/login/providers/account_provider_interface.h
+++ b/src/login/providers/account_provider_interface.h
@@ -25,7 +25,7 @@
 #include <string>
 #include <tuple>
 
-#include "login/account.h"
+#include "swganh/login/account.h"
 
 namespace login {
 namespace providers {
@@ -34,7 +34,7 @@ class AccountProviderInterface {
 public:
     virtual ~AccountProviderInterface() {}
 
-    virtual std::shared_ptr<login::Account> FindByUsername(std::string username) = 0;
+    virtual std::shared_ptr<swganh::login::Account> FindByUsername(std::string username) = 0;
     virtual uint32_t FindBySessionKey(const std::string& session_key) = 0;
     virtual bool CreateAccountSession(uint32_t account_id, const std::string& session_key) = 0;
 };

--- a/src/login/providers/mysql_account_provider.cc
+++ b/src/login/providers/mysql_account_provider.cc
@@ -36,6 +36,7 @@
 
 using namespace login;
 using namespace providers;
+using namespace swganh::login;
 using namespace std;
 
 MysqlAccountProvider::MysqlAccountProvider(std::shared_ptr<anh::database::DatabaseManagerInterface> db_manager)

--- a/src/login/providers/mysql_account_provider.h
+++ b/src/login/providers/mysql_account_provider.h
@@ -34,7 +34,7 @@ public:
     explicit MysqlAccountProvider(std::shared_ptr<anh::database::DatabaseManagerInterface> db_manager);
     ~MysqlAccountProvider();
 
-    std::shared_ptr<login::Account> FindByUsername(std::string username);
+    std::shared_ptr<swganh::login::Account> FindByUsername(std::string username);
     uint32_t FindBySessionKey(const std::string& session_key);
     bool CreateAccountSession(uint32_t account_id, const std::string& session_key);
 private:

--- a/src/login/providers/mysql_account_provider_unittest.cc
+++ b/src/login/providers/mysql_account_provider_unittest.cc
@@ -26,8 +26,6 @@
 #include "anh/database/database_manager.h"
 #include "anh/utilities.h"
 #include "login/providers/mysql_account_provider.h"
-#include "login/account.h"
-#include "login/login_client.h"
 
 using namespace login::providers;
 

--- a/src/swganh/app/swganh_app.cc
+++ b/src/swganh/app/swganh_app.cc
@@ -118,6 +118,12 @@ void SwganhApp::Start() {
     // Start up a threadpool for running io_service based tasks/active objects
     for (uint32_t i = 0; i < boost::thread::hardware_concurrency(); ++i) {
         auto t = make_shared<boost::thread>(bind(&boost::asio::io_service::run, &kernel_->GetIoService()));
+        
+#ifdef _WIN32
+        HANDLE mtheHandle = t->native_handle();
+        SetPriorityClass(mtheHandle, REALTIME_PRIORITY_CLASS);
+#endif
+
         io_threads_.push_back(t);
     }
     kernel_->GetServiceManager()->Start();

--- a/src/swganh/base/swg_message_router.h
+++ b/src/swganh/base/swg_message_router.h
@@ -1,0 +1,155 @@
+/*
+ This file is part of MMOServer. For more information, visit http://swganh.com
+ 
+ Copyright (c) 2006 - 2010 The SWG:ANH Team
+
+ MMOServer is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ MMOServer is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with MMOServer.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SWGANH_BASE_SWG_MESSAGE_ROUTER_H_
+#define SWGANH_BASE_SWG_MESSAGE_ROUTER_H_
+
+#include <exception>
+#include <functional>
+#include <memory>
+
+#include <boost/asio/ip/udp.hpp>
+#include <glog/logging.h>
+#include <tbb/concurrent_hash_map.h>
+
+namespace anh {
+class ByteBuffer;
+}  // namespace anh
+
+namespace anh {
+namespace network {
+namespace soe {
+class Packet;
+}}}  // namespace anh::network::soe
+
+namespace swganh {
+namespace base {
+      
+template<typename ClientType>
+class SwgMessageRouter {
+public:
+    typedef std::function<std::shared_ptr<ClientType> (
+        const boost::asio::ip::udp::endpoint&)
+    > ClientLookup;
+
+    typedef std::function<void (
+        std::shared_ptr<ClientType> client, 
+        std::shared_ptr<anh::network::soe::Packet> packet)
+    > MessageHandler;
+
+    typedef tbb::concurrent_hash_map<
+        anh::HashString,
+        std::pair<MessageHandler, bool> // bool IsClientRequired
+    > MessageHandlerMap;
+
+    typedef std::runtime_error HandlerAlreadyDefined;
+    typedef std::runtime_error UnidentifiedMessageReceived;
+    typedef std::runtime_error ValidClientRequired;
+
+    explicit SwgMessageRouter(ClientLookup&& lookup)
+        : find_client_(move(lookup)) {}
+
+    /**
+     * Register a handler with the connection service to be invoked whenever a message of the
+     * specified type is received. Throws an exception if a handler already exists.
+     *
+     * By default if a message is received from a source with no exising client registration the
+     * handler will throw a runtime_error. However, if the client_required flag is set to false
+     * then a new client object is created and given the session that generated the message.
+     *
+     * @param handler The handler to register with the connection service.
+     * @param client_required Defaults to true and should be the common case for nearly ever 
+     *                        message handler.
+     *
+     * @throws HandlerAlreadyDefined
+     */
+    template<typename MessageType>
+    void RegisterMessageHandler(
+        std::function<void (std::shared_ptr<ClientType>, MessageType)> handler,
+        bool client_required = true)
+    {
+        MessageHandlerMap::accessor a;
+        if (handlers_.find(a, MessageType::opcode)) {
+            DLOG(WARNING) << "Handler has already been defined: " << std::hex << MessageType::opcode;
+            throw HandlerAlreadyDefined("Requested registration of handler that has already been defined.");
+        }
+
+        auto wrapped_handler = [this, handler] (
+            std::shared_ptr<ClientType> client, 
+            std::shared_ptr<anh::network::soe::Packet> packet) 
+        {                        
+            MessageType message;
+            message.deserialize(*packet->message());        
+            
+            handler(client, message);
+        };
+
+        handlers_.insert(std::make_pair(MessageType::opcode, std::make_pair(wrapped_handler, client_required)));
+    }
+
+    /**
+     * Routes a message using the registered message handlers.
+     *
+     * @param packet The packet to route.
+     *
+     * @throws UnidentifiedMessageReceived
+     * @throws ValidClientRequired
+     */
+    void RouteMessage(std::shared_ptr<anh::network::soe::Packet> packet) {
+        auto message = packet->message();
+
+        uint32_t message_type = message->peekAt<uint32_t>(message->read_position() + sizeof(uint16_t));
+        
+        MessageHandlerMap::accessor a;
+
+        // No handler specified, trigger an event.
+        if (!handlers_.find(a, message_type)) {
+            DLOG(WARNING) << "Received message with no handler, triggering event: "
+                    << std::hex << message_type << "\n\n" << *message; 
+            
+            throw UnidentifiedMessageReceived("Received an unidentified message");
+
+            return;
+        }
+        
+        auto client = find_client_(packet->session()->remote_endpoint());
+
+        if (!client) {
+            if (a->second.second) {
+                DLOG(WARNING) << "Received a message from an invalid source: "
+                        << std::hex << message_type << "\n\n" << *message; 
+
+                throw ValidClientRequired("A valid client is required to invoke this message handler");
+            } else {
+                client = make_shared<ClientType>();
+                client->session = packet->session();
+            }
+        }
+
+        a->second.first(client, packet);
+    }
+
+private:    
+    MessageHandlerMap handlers_;
+    ClientLookup find_client_;
+};
+        
+}}  // namespace swganh::base
+
+#endif  // SWGANH_BASE_SWG_MESSAGE_ROUTER_H_

--- a/src/swganh/base/swg_message_router.h
+++ b/src/swganh/base/swg_message_router.h
@@ -28,6 +28,8 @@
 #include <glog/logging.h>
 #include <tbb/concurrent_hash_map.h>
 
+#include "anh/hash_string.h"
+
 namespace anh {
 class ByteBuffer;
 }  // namespace anh

--- a/src/swganh/character/messages/delete_character_message.h
+++ b/src/swganh/character/messages/delete_character_message.h
@@ -17,31 +17,35 @@
  along with MMOServer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef LOGIN_MESSAGES_DELETE_CHARACTER_REPLY_MESSAGE_H_
-#define LOGIN_MESSAGES_DELETE_CHARACTER_REPLY_MESSAGE_H_
+#ifndef SWGANH_CHARACTER_MESSAGES_DELETE_CHARACTER_MESSAGE_H_
+#define SWGANH_CHARACTER_MESSAGES_DELETE_CHARACTER_MESSAGE_H_
 
 #include <cstdint>
 #include "anh/byte_buffer.h"
 #include "swganh/base/swg_message.h"
 
-namespace login {
+namespace swganh {
+namespace character {
 namespace messages {
     
-struct DeleteCharacterReplyMessage : public swganh::base::SwgMessage<DeleteCharacterReplyMessage> {
-    static const uint16_t opcount = 2;
-    static const uint32_t opcode = 0x8268989B;
+struct DeleteCharacterMessage : public swganh::base::SwgMessage<DeleteCharacterMessage> {
+    static const uint16_t opcount = 3;
+    static const uint32_t opcode = 0xE87AD031;
 
-    int32_t failure_flag;
+    int32_t server_id;
+    uint64_t character_id;
+    
+    void onDeserialize(anh::ByteBuffer buffer) {
+        server_id = buffer.read<int32_t>();
+        character_id = buffer.read<uint64_t>();
+    }
     
     void onSerialize(anh::ByteBuffer& buffer) const {
-        buffer.write<int32_t>(failure_flag);
-    }
-
-    void onDeserialize(anh::ByteBuffer buffer) {
-        failure_flag = buffer.read<int32_t>();
+        buffer.write(server_id);
+        buffer.write(character_id);
     }
 };
 
-}}  // namespace login::messages
+}}}  // namespace swganh::character::messages
 
-#endif  // LOGIN_MESSAGES_DELETE_CHARACTER_REPLY_MESSAGE_H_
+#endif  // SWGANH_CHARACTER_MESSAGES_DELETE_CHARACTER_MESSAGE_H_

--- a/src/swganh/character/messages/delete_character_reply_message.h
+++ b/src/swganh/character/messages/delete_character_reply_message.h
@@ -17,34 +17,32 @@
  along with MMOServer.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef LOGIN_MESSAGES_DELETE_CHARACTER_MESSAGE_H_
-#define LOGIN_MESSAGES_DELETE_CHARACTER_MESSAGE_H_
+#ifndef SWGANH_CHARACTER_MESSAGES_DELETE_CHARACTER_REPLY_MESSAGE_H_
+#define SWGANH_CHARACTER_MESSAGES_DELETE_CHARACTER_REPLY_MESSAGE_H_
 
 #include <cstdint>
 #include "anh/byte_buffer.h"
 #include "swganh/base/swg_message.h"
 
-namespace login {
+namespace swganh {
+namespace character {
 namespace messages {
     
-struct DeleteCharacterMessage : public swganh::base::SwgMessage<DeleteCharacterMessage> {
-    static const uint16_t opcount = 3;
-    static const uint32_t opcode = 0xE87AD031;
+struct DeleteCharacterReplyMessage : public swganh::base::SwgMessage<DeleteCharacterReplyMessage> {
+    static const uint16_t opcount = 2;
+    static const uint32_t opcode = 0x8268989B;
 
-    int32_t server_id;
-    uint64_t character_id;
-    
-    void onDeserialize(anh::ByteBuffer buffer) {
-        server_id = buffer.read<int32_t>();
-        character_id = buffer.read<uint64_t>();
-    }
+    int32_t failure_flag;
     
     void onSerialize(anh::ByteBuffer& buffer) const {
-        buffer.write(server_id);
-        buffer.write(character_id);
+        buffer.write<int32_t>(failure_flag);
+    }
+
+    void onDeserialize(anh::ByteBuffer buffer) {
+        failure_flag = buffer.read<int32_t>();
     }
 };
 
-}}  // namespace login::messages
+}}}  // namespace swganh::character::messages
 
-#endif  // LOGIN_MESSAGES_DELETE_CHARACTER_MESSAGE_H_
+#endif  // SWGANH_CHARACTER_MESSAGES_DELETE_CHARACTER_REPLY_MESSAGE_H_

--- a/src/swganh/connection/base_connection_service.cc
+++ b/src/swganh/connection/base_connection_service.cc
@@ -28,11 +28,17 @@ using boost::asio::ip::udp;
 
 BaseConnectionService::BaseConnectionService(std::shared_ptr<anh::app::KernelInterface> kernel)
     : BaseService(kernel)
+#pragma warning(push)
+#pragma warning(disable: 4355)
+    , SwgMessageRouter([=] (const boost::asio::ip::udp::endpoint& endpoint) {
+        return GetClientFromEndpoint(endpoint);  
+      })
+#pragma warning(pop)
     , soe_server_(nullptr)
 {
     soe_server_.reset(new soe::Server(
         kernel->GetIoService(),
-        bind(&BaseConnectionService::HandleMessage, this, placeholders::_1)));
+        bind(&BaseConnectionService::RouteMessage, this, placeholders::_1)));
     soe_server_->event_dispatcher(kernel->GetEventDispatcher());
 }
 
@@ -81,44 +87,6 @@ shared_ptr<BaseCharacterService> BaseConnectionService::character_service() {
 
 shared_ptr<LoginServiceInterface> BaseConnectionService::login_service() {
     return login_service_;
-}
-
-void BaseConnectionService::HandleMessage(shared_ptr<soe::Packet> packet) 
-{
-    auto message = packet->message();
-
-    uint32_t message_type = message->peekAt<uint32_t>(message->read_position() + sizeof(uint16_t));
-    
-    MessageHandlerMap::accessor a;
-
-    // No handler specified, trigger an event.
-    if (!handlers_.find(a, message_type)) {
-        DLOG(WARNING) << "Received message with no handler, triggering event: "
-                << std::hex << message_type << "\n\n" << *message; 
-
-        kernel()->GetEventDispatcher()->trigger(
-            anh::event_dispatcher::make_shared_event(
-                message_type,
-                *packet));
-
-        return;
-    }
-    
-    auto client = GetClientFromEndpoint(packet->session()->remote_endpoint());
-
-    if (!client) {
-        if (a->second.second) {
-            DLOG(WARNING) << "Received a message from an invalid source: "
-                    << std::hex << message_type << "\n\n" << *message; 
-
-            throw std::runtime_error("A valid client is required to invoke this message handler");
-        } else {
-            client = make_shared<ConnectionClient>();
-            client->session = packet->session();
-        }
-    }
-
-    a->second.first(client, packet);
 }
 
 shared_ptr<ConnectionClient> BaseConnectionService::GetClientFromEndpoint(

--- a/src/swganh/connection/base_connection_service.cc
+++ b/src/swganh/connection/base_connection_service.cc
@@ -57,7 +57,7 @@ void BaseConnectionService::onStart() {
     soe_server_->Start(listen_port_);
     
     character_service_ = std::static_pointer_cast<BaseCharacterService>(kernel()->GetServiceManager()->GetService("CharacterService"));    
-    login_service_ = std::static_pointer_cast<swganh::login::LoginServiceInterface>(kernel()->GetServiceManager()->GetService("LoginService"));
+    login_service_ = std::static_pointer_cast<swganh::login::BaseLoginService>(kernel()->GetServiceManager()->GetService("LoginService"));
 }
 
 void BaseConnectionService::onStop() {
@@ -85,7 +85,7 @@ shared_ptr<BaseCharacterService> BaseConnectionService::character_service() {
     return character_service_;
 }
 
-shared_ptr<LoginServiceInterface> BaseConnectionService::login_service() {
+shared_ptr<BaseLoginService> BaseConnectionService::login_service() {
     return login_service_;
 }
 

--- a/src/swganh/connection/base_connection_service.h
+++ b/src/swganh/connection/base_connection_service.h
@@ -18,7 +18,7 @@
 #include "swganh/base/swg_message_router.h"
 
 #include "swganh/character/base_character_service.h"
-#include "swganh/login/login_service_interface.h"
+#include "swganh/login/base_login_service.h"
 
 namespace anh {
 namespace network {
@@ -65,7 +65,7 @@ protected:
     
     std::shared_ptr<swganh::character::BaseCharacterService> character_service();
 
-    std::shared_ptr<swganh::login::LoginServiceInterface> login_service();
+    std::shared_ptr<swganh::login::BaseLoginService> login_service();
 
 private:    
     ClientMap clients_;
@@ -73,7 +73,7 @@ private:
     std::unique_ptr<anh::network::soe::Server> soe_server_;
     
     std::shared_ptr<swganh::character::BaseCharacterService> character_service_;
-    std::shared_ptr<swganh::login::LoginServiceInterface> login_service_;
+    std::shared_ptr<swganh::login::BaseLoginService> login_service_;
 
     std::string listen_address_;
     uint16_t listen_port_;

--- a/src/swganh/connection/base_connection_service.h
+++ b/src/swganh/connection/base_connection_service.h
@@ -15,6 +15,7 @@
 #include "anh/network/soe/session.h"
 
 #include "swganh/base/base_service.h"
+#include "swganh/base/swg_message_router.h"
 
 #include "swganh/character/base_character_service.h"
 #include "swganh/login/login_service_interface.h"
@@ -30,25 +31,16 @@ namespace connection {
     
 struct ConnectionClient;
     
-class BaseConnectionService : public swganh::base::BaseService
+class BaseConnectionService 
+    : public swganh::base::BaseService
+    , public swganh::base::SwgMessageRouter<ConnectionClient>
 {
 public:
-    typedef std::function<void (
-        std::shared_ptr<ConnectionClient> client, 
-        std::shared_ptr<anh::network::soe::Packet> packet)
-    > MessageHandler;
-
     typedef tbb::concurrent_hash_map<
         boost::asio::ip::udp::endpoint, 
         std::shared_ptr<ConnectionClient>,
         anh::network::soe::EndpointHashCompare
     > ClientMap;
-
-    typedef tbb::concurrent_hash_map<
-        anh::HashString,
-        std::pair<MessageHandler, bool> // bool IsClientRequired
-    > MessageHandlerMap;
-
 public:
     explicit BaseConnectionService(std::shared_ptr<anh::app::KernelInterface> kernel);
     
@@ -56,46 +48,6 @@ public:
 
     void onStart();
     void onStop();
-
-    /**
-     * Register a handler with the connection service to be invoked whenever a message of the
-     * specified type is received. Throws an exception if a handler already exists.
-     *
-     * By default if a message is received from a source with no exising client registration the
-     * handler will throw a runtime_error. However, if the client_required flag is set to false
-     * then a new client object is created and given the session that generated the message.
-     *
-     * @param handler The handler to register with the connection service.
-     * @param client_required Defaults to true and should be the common case for nearly ever 
-     *                        message handler.
-     *
-     * @throws std::runtime_exception
-     */
-    template<typename MessageType>
-    void RegisterMessageHandler(
-        std::function<void (std::shared_ptr<ConnectionClient>, MessageType)> handler,
-        bool client_required = true)
-    {
-        MessageHandlerMap::accessor a;
-        if (handlers_.find(a, MessageType::opcode)) {
-            DLOG(WARNING) << "Handler has already been defined: " << std::hex << MessageType::opcode;
-            throw std::runtime_error("Requested registration of handler that has already been defined.");
-        }
-
-        auto wrapped_handler = [this, handler] (
-            std::shared_ptr<ConnectionClient> client, 
-            std::shared_ptr<anh::network::soe::Packet> packet) 
-        {                        
-            MessageType message;
-            message.deserialize(*packet->message());        
-            
-            handler(client, message);
-        };
-
-        handlers_.insert(std::make_pair(MessageType::opcode, std::make_pair(wrapped_handler, client_required)));
-    }
-    
-    void HandleMessage(std::shared_ptr<anh::network::soe::Packet> packet);
     
     std::shared_ptr<ConnectionClient> GetClientFromEndpoint(
         const boost::asio::ip::udp::endpoint& remote_endpoint);
@@ -117,7 +69,6 @@ protected:
 
 private:    
     ClientMap clients_;
-    MessageHandlerMap handlers_;
     
     std::unique_ptr<anh::network::soe::Server> soe_server_;
     

--- a/src/swganh/connection/messages/logout_message.h
+++ b/src/swganh/connection/messages/logout_message.h
@@ -1,0 +1,23 @@
+#ifndef SWGANH_CONNECTION_MESSAGES_LOGOUT_MESSAGE_H_
+#define SWGANH_CONNECTION_MESSAGES_LOGOUT_MESSAGE_H_
+
+#include <cstdint>
+#include "anh/byte_buffer.h"
+#include "swganh/base/swg_message.h"
+
+namespace swganh {
+namespace connection {
+namespace messages {
+    
+struct LogoutMessage : public swganh::base::SwgMessage<LogoutMessage> {
+    static const uint16_t opcount = 1;
+    static const uint32_t opcode = 0x42FD19DD;
+    
+    void onSerialize(anh::ByteBuffer& buffer) const {}
+
+    void onDeserialize(anh::ByteBuffer buffer) {}
+};
+
+}}}  // namespace swganh::connection::messages
+
+#endif // SWGANH_CONNECTION_MESSAGES_LOGOUT_MESSAGE_H_

--- a/src/swganh/login/account.cc
+++ b/src/swganh/login/account.cc
@@ -18,9 +18,9 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#include "login/account.h"
+#include "swganh/login/account.h"
 
-using namespace login;
+using namespace swganh::login;
 using namespace std;
 
 Account::Account(bool enabled) 

--- a/src/swganh/login/account.h
+++ b/src/swganh/login/account.h
@@ -18,31 +18,50 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#ifndef LOGIN_LOGIN_CLIENT_H_
-#define LOGIN_LOGIN_CLIENT_H_
+#ifndef SWGANH_LOGIN_ACCOUNT_H_
+#define SWGANH_LOGIN_ACCOUNT_H_
 
-#include <memory>
+#include <cstdint>
 #include <string>
 
-namespace anh {
-namespace network {
-namespace soe {
-class Session;
-}}}  // namespace anh::network::soe
-
+namespace swganh {
 namespace login {
 
-class Account;
+class Account {
+public:
+    explicit Account(bool enabled = false);
+    ~Account();
 
-struct LoginClient {
-    std::string username;
-    std::string password;
-    std::string version;
+    uint32_t account_id() const;
+    void account_id(uint32_t account_id);
 
-    std::shared_ptr<Account> account;
-    std::shared_ptr<anh::network::soe::Session> session;
+    std::string username() const;
+    void username(std::string username);
+
+    std::string salt() const;
+    void salt(std::string salt);
+
+    std::string password() const;
+    void password(std::string password);
+
+    std::string algorithm() const;
+    void algorithm(std::string algorithm);
+
+    bool IsEnabled() const;
+    void Enable();
+    void Disable();   
+
+protected:
+    std::string username_;
+    std::string password_;
+    std::string salt_;
+    std::string algorithm_;
+
+    uint32_t account_id_;
+
+    bool enabled_;
 };
 
-}  // namespace login
+}}  // namespace swganh::login
 
-#endif  // LOGIN_LOGIN_CLIENT_H_
+#endif  // SWGANH_LOGIN_ACCOUNT_H_

--- a/src/swganh/login/base_login_service.cc
+++ b/src/swganh/login/base_login_service.cc
@@ -1,0 +1,18 @@
+
+#include "swganh/login/base_login_service.h"
+
+using namespace anh::app;
+using namespace swganh::base;
+using namespace swganh::login;
+
+using namespace std;
+
+BaseLoginService::BaseLoginService(shared_ptr<KernelInterface> kernel) 
+    : BaseService(kernel)
+#pragma warning(push)
+#pragma warning(disable: 4355)
+    , SwgMessageRouter([=] (const boost::asio::ip::udp::endpoint& endpoint) {
+        return GetClientFromEndpoint(endpoint);  
+      })
+#pragma warning(pop) 
+{}

--- a/src/swganh/login/base_login_service.h
+++ b/src/swganh/login/base_login_service.h
@@ -18,13 +18,14 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#ifndef SWGANH_LOGIN_SERVICE_INTERFACE_H_
-#define SWGANH_LOGIN_SERVICE_INTERFACE_H_
+#ifndef SWGANH_LOGIN_BASE_LOGIN_SERVICE_H_
+#define SWGANH_LOGIN_BASE_LOGIN_SERVICE_H_
 
 #include <map>
 #include <tuple>
 
 #include "swganh/base/base_service.h"
+#include "swganh/base/swg_message_router.h"
 
 namespace anh {
 namespace app {
@@ -34,17 +35,22 @@ class KernelInterface;
 namespace swganh {
 namespace login {
 
-class LoginServiceInterface : public swganh::base::BaseService {
+struct LoginClient;
+
+class BaseLoginService 
+    : public swganh::base::BaseService 
+    , public swganh::base::SwgMessageRouter<LoginClient> {
 public:
-    explicit LoginServiceInterface(std::shared_ptr<anh::app::KernelInterface> kernel) 
-        : swganh::base::BaseService(kernel) {}
-    virtual ~LoginServiceInterface(){}
+    explicit BaseLoginService(std::shared_ptr<anh::app::KernelInterface> kernel);
     
     virtual anh::service::ServiceDescription GetServiceDescription() = 0;
 
     virtual void DescribeConfigOptions(boost::program_options::options_description& description) = 0;
     virtual uint32_t GetAccountBySessionKey(const std::string& session_key) = 0;
+    
+    virtual std::shared_ptr<LoginClient> GetClientFromEndpoint(
+        const boost::asio::ip::udp::endpoint& remote_endpoint) = 0;
 };
 
 }}  // namespace swganh::login
-#endif  // SWGANH_LOGIN_SERVICE_INTERFACE_H_
+#endif  // SWGANH_LOGIN_BASE_LOGIN_SERVICE_H_

--- a/src/swganh/login/login_client.h
+++ b/src/swganh/login/login_client.h
@@ -18,49 +18,32 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-#ifndef LOGIN_ACCOUNT_H_
-#define LOGIN_ACCOUNT_H_
+#ifndef SWGANH_LOGIN_LOGIN_CLIENT_H_
+#define SWGANH_LOGIN_LOGIN_CLIENT_H_
 
-#include <cstdint>
+#include <memory>
 #include <string>
 
+namespace anh {
+namespace network {
+namespace soe {
+class Session;
+}}}  // namespace anh::network::soe
+
+namespace swganh {
 namespace login {
 
-class Account {
-public:
-    explicit Account(bool enabled = false);
-    ~Account();
+class Account;
 
-    uint32_t account_id() const;
-    void account_id(uint32_t account_id);
+struct LoginClient {
+    std::string username;
+    std::string password;
+    std::string version;
 
-    std::string username() const;
-    void username(std::string username);
-
-    std::string salt() const;
-    void salt(std::string salt);
-
-    std::string password() const;
-    void password(std::string password);
-
-    std::string algorithm() const;
-    void algorithm(std::string algorithm);
-
-    bool IsEnabled() const;
-    void Enable();
-    void Disable();   
-
-protected:
-    std::string username_;
-    std::string password_;
-    std::string salt_;
-    std::string algorithm_;
-
-    uint32_t account_id_;
-
-    bool enabled_;
+    std::shared_ptr<Account> account;
+    std::shared_ptr<anh::network::soe::Session> session;
 };
 
-}  // namespace login
+}}  // namespace swganh::login
 
-#endif  // LOGIN_ACCOUNT_H_
+#endif  // SWGANH_LOGIN_LOGIN_CLIENT_H_


### PR DESCRIPTION
Moves the swg message routing out to a mixin class that both Login and Connection services use.

Moved character deletion out to the Character service.

Future improvements: consolidate the Login/Connection client structs into a SwgClient struct.
