### PR TITLE
Server mode configuration.

### DIFF
--- a/data/config/swganh.cfg
+++ b/data/config/swganh.cfg
@@ -1,4 +1,4 @@
-single_server_mode = true
+server_mode = all
 
 galaxy_name = A New Hope
 

--- a/src/swganh/app/swganh_kernel.h
+++ b/src/swganh/app/swganh_kernel.h
@@ -16,7 +16,7 @@ namespace swganh {
 namespace app {
     
 struct AppConfig {
-    bool single_server_mode;
+	std::string server_mode;
     std::vector<std::string> plugins;
     std::string plugin_directory;
     std::string galaxy_name;


### PR DESCRIPTION
Removed single_server_mode and replaced with server_mode, which is a string to determine what service mode the server should run in (login, connection, simulation, or all). This will start the correct services that are needed for the configuration.
