### PR TITLE
Pvp Update Message

### DIFF
--- a/src/swganh/connection/connection_service.cc
+++ b/src/swganh/connection/connection_service.cc
@@ -197,8 +197,12 @@ void ConnectionService::RemoveClient_(std::shared_ptr<anh::network::soe::Session
         if (controller)
         {
             auto simulation_service = simulation_service_.lock();
+
+            // @TODO REFACTOR Move this functionality out to a PlayerService
             auto player = simulation_service->GetObjectById<swganh::object::player::Player>(controller->GetObject()->GetObjectId() + 1);
 			player->AddStatusFlag(swganh::object::player::LD);
+            // END TODO
+
             simulation_service->PersistRelatedObjects(controller->GetObject()->GetObjectId());
             
             // set a timer to 5 minutes to destroy the object, unless logged back in.

--- a/src/swganh/object/creature/creature.h
+++ b/src/swganh/object/creature/creature.h
@@ -134,6 +134,18 @@ enum State
     PILOTING_POB_SHIP
 };
 
+enum PvpStatus
+{
+    PvPStatus_None          = 0x00000000,
+    PvPStatus_Attackable    = 0x00000001,
+    PvPStatus_Aggressive    = 0x00000002,
+    PvPStatus_Overt         = 0x00000004,
+    PvPStatus_Tef           = 0x00000008,
+    PvPStatus_Player        = 0x00000010,
+    PvPStatus_Enemy         = 0x00000020,
+    PvPStatus_Duel          = 0x00000040
+};
+
 /**
  *
  */
@@ -523,6 +535,13 @@ public:
     void SetStationary(bool stationary);
     bool IsStationary(void);
 
+    PvpStatus GetPvpStatus() const;
+    void SetPvPStatus(PvpStatus status);
+    void TogglePvpStateOn(PvpStatus state);
+    void TogglePvpStateOff(PvpStatus state);
+    void TogglePvpState(PvpStatus state);
+    bool CheckPvpState(PvpStatus state) const;
+
     // Baselines
     virtual boost::optional<swganh::messages::BaselinesMessage> GetBaseline1();
     virtual boost::optional<swganh::messages::BaselinesMessage> GetBaseline3();
@@ -532,6 +551,8 @@ public:
 private:
     friend class CreatureMessageBuilder;
     friend class CreatureFactory;
+
+    void OnMakeClean(std::shared_ptr<swganh::object::ObjectController> controller);
 
     uint32_t    bank_credits_;                                                              // update 1 variable 0
     uint32_t    cash_credits_;                                                              // update 1 variable 1
@@ -575,7 +596,7 @@ private:
     swganh::messages::containers::NetworkSortedList<EquipmentItem> equipment_list_;         // update 6 variable 15
     std::string disguise_;                                                                  // update 6 variable 16
     bool stationary_;                                                                       // update 6 variable 17
-
+    PvpStatus pvp_status_;
 };
 
 }}}  // namespace swganh::object::creature

--- a/src/swganh/object/creature/creature_message_builder.cc
+++ b/src/swganh/object/creature/creature_message_builder.cc
@@ -1,5 +1,6 @@
 #include "creature_message_builder.h"
 #include "creature.h"
+#include "swganh/messages/update_pvp_status_message.h"
 
 using namespace swganh::object::creature;
 using namespace swganh::messages;
@@ -423,6 +424,19 @@ void CreatureMessageBuilder::BuildStationaryDelta(Creature* creature)
     }
 }
 
+
+void CreatureMessageBuilder::BuildUpdatePvpStatusMessage(Creature* creature)
+{
+    if (creature->HasObservers())
+    {
+        UpdatePvpStatusMessage message;
+        message.object_id = creature->object_id_;
+        message.faction = 0;
+        message.pvp_status = creature->pvp_status_;
+
+        creature->NotifyObservers(message);
+    }
+}
 
 boost::optional<swganh::messages::BaselinesMessage> CreatureMessageBuilder::BuildBaseline1(Creature* creature)
 {

--- a/src/swganh/object/creature/creature_message_builder.h
+++ b/src/swganh/object/creature/creature_message_builder.h
@@ -77,6 +77,7 @@ public:
     static void BuildEquipmentDelta(Creature* creature);
     static void BuildDisguiseDelta(Creature* creature);
     static void BuildStationaryDelta(Creature* creature);
+    static void BuildUpdatePvpStatusMessage(Creature* object);
 
     // baselines
     static boost::optional<swganh::messages::BaselinesMessage> BuildBaseline1(Creature* creature);

--- a/src/swganh/object/object.cc
+++ b/src/swganh/object/object.cc
@@ -314,6 +314,8 @@ void Object::MakeClean(std::shared_ptr<swganh::object::ObjectController> control
     swganh::messages::SceneEndBaselines scene_end_baselines;
     scene_end_baselines.object_id = GetObjectId();
     controller->Notify(scene_end_baselines);
+
+    OnMakeClean(controller);
 }
 
 const BaselinesCacheContainer& Object::GetBaselines(uint64_t viewer_id) 

--- a/src/swganh/object/object.h
+++ b/src/swganh/object/object.h
@@ -426,7 +426,7 @@ protected:
     
     swganh::messages::DeltasMessage CreateDeltasMessage(uint16_t view_type, uint16_t update_type, uint16_t update_count = 1) ;
 
-    boost::recursive_mutex    mutex_;
+    mutable boost::recursive_mutex mutex_;
 	uint64_t object_id_;             // create
 	uint32_t scene_id_;				 // create
     std::string template_string_;    // create

--- a/src/swganh/object/object.h
+++ b/src/swganh/object/object.h
@@ -217,7 +217,7 @@ public:
     template<typename T>
     void NotifyObservers(const T& message)
     {
-        for_each(
+        std::for_each(
             observers_.begin(),
             observers_.end(),
             [&message] (const std::shared_ptr<anh::observer::ObserverInterface>& observer)
@@ -411,6 +411,7 @@ public:
     virtual uint32_t GetType() const { return 0; }
             
 protected:
+    virtual void OnMakeClean(std::shared_ptr<swganh::object::ObjectController> controller) {}
     
     virtual boost::optional<swganh::messages::BaselinesMessage> GetBaseline1() { return boost::optional<swganh::messages::BaselinesMessage>(); }
     virtual boost::optional<swganh::messages::BaselinesMessage> GetBaseline2() { return boost::optional<swganh::messages::BaselinesMessage>(); }

--- a/src/swganh/object/player/player.cc
+++ b/src/swganh/object/player/player.cc
@@ -1,6 +1,8 @@
 
 #include "swganh/object/player/player.h"
 
+#include <glog/logging.h>
+
 #include "anh/crc.h"
 
 #include "swganh/object/player/player_message_builder.h"
@@ -740,42 +742,6 @@ void Player::SetGender(Gender value)
 {
     boost::lock_guard<boost::recursive_mutex> lock(mutex_);
     gender_ = value;
-}
-
-PvpStatus Player::GetPvpStatus() const
-{
-    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
-    return pvp_status_;
-}
-
-void Player::SetPvPStatus(PvpStatus status)
-{
-    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
-    pvp_status_ = status;
-}
-
-void Player::TogglePvpStateOn(PvpStatus state)
-{
-    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
-    pvp_status_ = static_cast<PvpStatus>(pvp_status_ | state);
-}
-
-void Player::TogglePvpStateOff(PvpStatus state)
-{
-    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
-    pvp_status_ = static_cast<PvpStatus>(pvp_status_ & ~state);
-}
-
-void Player::TogglePvpState(PvpStatus state)
-{
-    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
-    pvp_status_ = static_cast<PvpStatus>(pvp_status_ ^ state);
-}
-
-bool Player::CheckPvpState(PvpStatus state) const
-{
-    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
-    return static_cast<PvpStatus>(pvp_status_ & state) == state;
 }
 
 boost::optional<BaselinesMessage> Player::GetBaseline3()

--- a/src/swganh/object/player/player.cc
+++ b/src/swganh/object/player/player.cc
@@ -742,6 +742,42 @@ void Player::SetGender(Gender value)
     gender_ = value;
 }
 
+PvpStatus Player::GetPvpStatus() const
+{
+    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+    return pvp_status_;
+}
+
+void Player::SetPvPStatus(PvpStatus status)
+{
+    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+    pvp_status_ = status;
+}
+
+void Player::TogglePvpStateOn(PvpStatus state)
+{
+    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+    pvp_status_ = static_cast<PvpStatus>(pvp_status_ | state);
+}
+
+void Player::TogglePvpStateOff(PvpStatus state)
+{
+    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+    pvp_status_ = static_cast<PvpStatus>(pvp_status_ & ~state);
+}
+
+void Player::TogglePvpState(PvpStatus state)
+{
+    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+    pvp_status_ = static_cast<PvpStatus>(pvp_status_ ^ state);
+}
+
+bool Player::CheckPvpState(PvpStatus state) const
+{
+    boost::lock_guard<boost::recursive_mutex> lock(mutex_);
+    return static_cast<PvpStatus>(pvp_status_ & state) == state;
+}
+
 boost::optional<BaselinesMessage> Player::GetBaseline3()
 {
     return PlayerMessageBuilder::BuildBaseline3(this);

--- a/src/swganh/object/player/player.h
+++ b/src/swganh/object/player/player.h
@@ -54,6 +54,19 @@ enum AdminTag
     CSR = 1,
     DEVELOPER = 2
 };
+
+enum PvpStatus
+{
+    PvPStatus_None          = 0x00000000,
+    PvPStatus_Attackable    = 0x00000001,
+    PvPStatus_Aggressive    = 0x00000002,
+    PvPStatus_Overt         = 0x00000004,
+    PvPStatus_Tef           = 0x00000008,
+    PvPStatus_Player        = 0x00000010,
+    PvPStatus_Enemy         = 0x00000020,
+    PvPStatus_Duel          = 0x00000040
+};
+
 struct Ability
 {
     Ability(void)
@@ -896,6 +909,12 @@ public:
      */
     void SetGender(Gender gender);
 
+    PvpStatus GetPvpStatus() const;
+    void SetPvPStatus(PvpStatus status);
+    void TogglePvpStateOn(PvpStatus state);
+    void TogglePvpStateOff(PvpStatus state);
+    void TogglePvpState(PvpStatus state);
+    bool CheckPvpState(PvpStatus state) const;
 
 protected:
     // baselines
@@ -942,6 +961,7 @@ private:
     uint32_t max_drink_;
     uint32_t jedi_state_;
     Gender gender_;
+    PvpStatus pvp_status_;
 };
 
 }}}  // namespace swganh::object::player

--- a/src/swganh/object/player/player.h
+++ b/src/swganh/object/player/player.h
@@ -55,18 +55,6 @@ enum AdminTag
     DEVELOPER = 2
 };
 
-enum PvpStatus
-{
-    PvPStatus_None          = 0x00000000,
-    PvPStatus_Attackable    = 0x00000001,
-    PvPStatus_Aggressive    = 0x00000002,
-    PvPStatus_Overt         = 0x00000004,
-    PvPStatus_Tef           = 0x00000008,
-    PvPStatus_Player        = 0x00000010,
-    PvPStatus_Enemy         = 0x00000020,
-    PvPStatus_Duel          = 0x00000040
-};
-
 struct Ability
 {
     Ability(void)
@@ -909,13 +897,6 @@ public:
      */
     void SetGender(Gender gender);
 
-    PvpStatus GetPvpStatus() const;
-    void SetPvPStatus(PvpStatus status);
-    void TogglePvpStateOn(PvpStatus state);
-    void TogglePvpStateOff(PvpStatus state);
-    void TogglePvpState(PvpStatus state);
-    bool CheckPvpState(PvpStatus state) const;
-
 protected:
     // baselines
     virtual boost::optional<swganh::messages::BaselinesMessage> GetBaseline3();
@@ -961,7 +942,6 @@ private:
     uint32_t max_drink_;
     uint32_t jedi_state_;
     Gender gender_;
-    PvpStatus pvp_status_;
 };
 
 }}}  // namespace swganh::object::player

--- a/src/swganh/simulation/simulation_service.cc
+++ b/src/swganh/simulation/simulation_service.cc
@@ -276,7 +276,24 @@ public:
         {
             object = LoadObjectById(message.character_id, creature::Creature::type);
         }
+
+        // @TODO REFACTOR Move this functionality out to a PlayerService
+        auto contained = object->GetContainedObjects();
         
+        for_each(
+            begin(contained),
+            end(contained),
+            [] (Object::ObjectMap::value_type& object_entry)
+        {
+            auto player = dynamic_pointer_cast<player::Player>(object_entry.second);
+
+            if (player)
+            {
+                player->RemoveStatusFlag(player::LD);
+            }
+        });
+        // END TODO
+
         StartControllingObject(object, client);
 
         auto scene = scene_manager_->GetScene(object->GetSceneId());


### PR DESCRIPTION
This message is sent during the initial baseline handshaking. Is also necessary for some reason for enabling the player status flags in the PLAY3 message.

Fixes bug with LD status not showing.
