### PR TITLE
Equipment Management

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/meshlib"]
-	path = src/meshlib
-	url = git://github.com/apathyboy/meshlib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/meshlib"]
+	path = src/meshlib
+	url = git://github.com/apathyboy/meshlib.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,6 @@ endif()
 
 ## project libraries
 add_subdirectory(anh)
-add_subdirectory(meshlib)
 
 ## project executables
 add_subdirectory(swganh)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 ## project libraries
 add_subdirectory(anh)
+add_subdirectory(meshlib)
 
 ## project executables
 add_subdirectory(swganh)

--- a/src/pub14_core/simulation/simulation_service.cc
+++ b/src/pub14_core/simulation/simulation_service.cc
@@ -40,6 +40,7 @@
 
 // message builders
 #include "swganh/object/creature/creature_message_builder.h"
+#include "swganh/object/intangible/intangible_message_builder.h"
 #include "swganh/object/tangible/tangible_message_builder.h"
 #include "swganh/object/player/player_message_builder.h"
 
@@ -50,6 +51,8 @@
 #include "swganh/messages/cmd_scene_ready.h"
 #include "swganh/messages/obj_controller_message.h"
 #include "swganh/messages/update_containment_message.h"
+
+#include "swganh/tre/tre_archive.h"
 
 #include "movement_manager.h"
 #include "scene_manager.h"
@@ -84,7 +87,7 @@ public:
     {
         if (!object_manager_)
         {
-            object_manager_ = make_shared<ObjectManager>(kernel_->GetEventDispatcher());
+            object_manager_ = make_shared<ObjectManager>(kernel_->GetEventDispatcher(), kernel_->GetDatabaseManager());
         }
 
         return object_manager_;
@@ -497,17 +500,13 @@ void SimulationService::StopScene(const std::string& scene_label)
 }
 void SimulationService::RegisterObjectFactories()
 {
-        auto db_manager = kernel_->GetDatabaseManager();
-        auto event_dispatcher =  kernel_->GetEventDispatcher();
-        impl_->GetObjectManager()->RegisterObjectType(0, make_shared<ObjectFactory>(db_manager, this, event_dispatcher));
-        impl_->GetObjectManager()->RegisterObjectType(tangible::Tangible::type, make_shared<tangible::TangibleFactory>(db_manager, this, event_dispatcher));
-        impl_->GetObjectManager()->RegisterObjectType(intangible::Intangible::type, make_shared<intangible::IntangibleFactory>(db_manager, this, event_dispatcher));
-        impl_->GetObjectManager()->RegisterObjectType(creature::Creature::type, make_shared<creature::CreatureFactory>(db_manager, this, event_dispatcher));
-        impl_->GetObjectManager()->RegisterObjectType(player::Player::type, make_shared<player::PlayerFactory>(db_manager, this, event_dispatcher));
-        // register message builders
-        impl_->GetObjectManager()->RegisterMessageBuilder(tangible::Tangible::type, make_shared<tangible::TangibleMessageBuilder>(event_dispatcher));
-        impl_->GetObjectManager()->RegisterMessageBuilder(creature::Creature::type, make_shared<creature::CreatureMessageBuilder>(event_dispatcher));
-        impl_->GetObjectManager()->RegisterMessageBuilder(player::Player::type, make_shared<player::PlayerMessageBuilder>(event_dispatcher));
+    auto object_manager = impl_->GetObjectManager();
+
+    object_manager->RegisterObjectType<Object>();
+    object_manager->RegisterObjectType<tangible::Tangible>();
+    object_manager->RegisterObjectType<intangible::Intangible>();
+    object_manager->RegisterObjectType<creature::Creature>();
+    object_manager->RegisterObjectType<player::Player>();
 }
 
 void SimulationService::PersistObject(uint64_t object_id)

--- a/src/swganh/object/creature/creature.h
+++ b/src/swganh/object/creature/creature.h
@@ -352,12 +352,18 @@ struct SkillCommands
 
 };
 
+class CreatureFactory;
+class CreatureMessageBuilder;
+
 /**
  *
  */
 class Creature : public swganh::object::tangible::Tangible
 {
 public:
+    typedef CreatureFactory FactoryType;
+    typedef CreatureMessageBuilder MessageBuilderType;
+
     Creature();
     ~Creature();
 

--- a/src/swganh/object/creature/creature_factory.cc
+++ b/src/swganh/object/creature/creature_factory.cc
@@ -26,9 +26,8 @@ using namespace swganh::simulation;
 
 
 CreatureFactory::CreatureFactory(DatabaseManagerInterface* db_manager,
-                             SimulationServiceInterface* simulation_service,
                              anh::EventDispatcher* event_dispatcher)
-    : TangibleFactory(db_manager, simulation_service, event_dispatcher)
+    : TangibleFactory(db_manager, event_dispatcher)
 {
 }
 

--- a/src/swganh/object/creature/creature_factory.h
+++ b/src/swganh/object/creature/creature_factory.h
@@ -17,11 +17,6 @@ namespace sql {
 }  // namespace sql
 
 namespace swganh {
-namespace simulation {
-    class SimulationServiceInterface;
-}}  // namespace swganh::simulation
-
-namespace swganh {
 namespace object {
 namespace creature {
 
@@ -30,7 +25,6 @@ namespace creature {
     {
     public:
         CreatureFactory(anh::database::DatabaseManagerInterface* db_manager,
-            swganh::simulation::SimulationServiceInterface* simulation_service,
             anh::EventDispatcher* event_dispatcher);
 
         void LoadTemplates();

--- a/src/swganh/object/intangible/intangible.h
+++ b/src/swganh/object/intangible/intangible.h
@@ -14,10 +14,16 @@
 namespace swganh {
 namespace object {
 namespace intangible {
+
+class IntangibleFactory;
+class IntangibleMessageBuilder;
     
 class Intangible : public swganh::object::Object
 {
 public:
+    typedef IntangibleFactory FactoryType;
+    typedef IntangibleMessageBuilder MessageBuilderType;
+
     // ITNO
     /**
      * @return The type of this object instance.

--- a/src/swganh/object/intangible/intangible_factory.cc
+++ b/src/swganh/object/intangible/intangible_factory.cc
@@ -25,9 +25,8 @@ using namespace swganh::object::intangible;
 using namespace swganh::simulation;
 
 IntangibleFactory::IntangibleFactory(DatabaseManagerInterface* db_manager,
-                             SimulationServiceInterface* simulation_service,
                              anh::EventDispatcher* event_dispatcher)
-    : ObjectFactory(db_manager, simulation_service, event_dispatcher)
+    : ObjectFactory(db_manager, event_dispatcher)
 {
 }
 void IntangibleFactory::LoadTemplates()

--- a/src/swganh/object/intangible/intangible_factory.h
+++ b/src/swganh/object/intangible/intangible_factory.h
@@ -13,11 +13,6 @@ class DatabaseManagerInterface;
 }} // anh::database
 
 namespace swganh {
-namespace simulation {
-    class SimulationServiceInterface;
-}}  // namespace swganh::simulation
-
-namespace swganh {
 namespace object {
 namespace intangible {
     class Intangible;
@@ -26,7 +21,6 @@ namespace intangible {
     {
     public:
         IntangibleFactory(anh::database::DatabaseManagerInterface* db_manager,
-            swganh::simulation::SimulationServiceInterface* simulation_service,
             anh::EventDispatcher* event_dispatcher);
         void LoadTemplates();
 

--- a/src/swganh/object/object.h
+++ b/src/swganh/object/object.h
@@ -42,9 +42,18 @@ typedef std::vector<
     swganh::messages::DeltasMessage
 > DeltasCacheContainer;
 
+class ObjectFactory;
+class ObjectMessageBuilder;
+
+
 class Object : public anh::observer::ObservableInterface, public std::enable_shared_from_this<Object>
 {
 public:
+    const static uint32_t type = 0;
+
+    typedef ObjectFactory FactoryType;
+    typedef ObjectMessageBuilder MessageBuilderType;
+
     enum ViewType : uint16_t
     {
         VIEW_1 = 1,

--- a/src/swganh/object/object_factory.cc
+++ b/src/swganh/object/object_factory.cc
@@ -14,6 +14,7 @@
 
 #include "anh/database/database_manager.h"
 #include "swganh/object/object.h"
+#include "swganh/object/object_manager.h"
 #include "swganh/object/exception.h"
 #include "swganh/simulation/simulation_service_interface.h"
 
@@ -24,13 +25,11 @@ using namespace swganh::object;
 using namespace swganh::simulation;
 
 ObjectFactory::ObjectFactory(DatabaseManagerInterface* db_manager,
-                             SimulationServiceInterface* simulation_service,
                              anh::EventDispatcher* event_dispatcher)
     : db_manager_(db_manager)
-    , simulation_service_(simulation_service)
     , event_dispatcher_(event_dispatcher)
-{
-}
+{}
+
 void ObjectFactory::PersistObject(const shared_ptr<Object>& object)
 {
     try {
@@ -47,6 +46,7 @@ void ObjectFactory::PersistObject(const shared_ptr<Object>& object)
         LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
     }
 }
+
 void ObjectFactory::PersistObject(const shared_ptr<Object>& object, const shared_ptr<sql::PreparedStatement>& prepared_statement)
 {
     try {
@@ -154,8 +154,9 @@ void ObjectFactory::LoadContainedObjects(
         {
             contained_id = result->getUInt64("id");
             contained_type = result->getUInt("type_id");
-            auto contained_object = simulation_service_->LoadObjectById(contained_id, contained_type);
 
+            auto contained_object = object_manager_->CreateObjectFromStorage(contained_id, contained_type);
+            
             object->AddContainedObject(contained_object, Object::LINK);
         }
     }

--- a/src/swganh/object/object_factory.h
+++ b/src/swganh/object/object_factory.h
@@ -21,20 +21,27 @@ namespace sql {
 namespace swganh {
 namespace simulation {
     class SimulationServiceInterface;
-}}  // namespace swganh::simulation
+}
+
+namespace tre {
+    class TreArchive;
+}}  // namespace swganh::tre
 
 namespace swganh {
 namespace object {
 
     class Object;
+    class ObjectManager;
 
     class ObjectFactory : public ObjectFactoryInterface
     {
     public:
         ObjectFactory(anh::database::DatabaseManagerInterface* db_manager,
-            swganh::simulation::SimulationServiceInterface* simulation_service,
             anh::EventDispatcher* event_dispatcher);
         virtual ~ObjectFactory() {}
+
+        void SetObjectManager(ObjectManager* object_manager) { object_manager_ = object_manager; }
+
         /**
          * Loads in base values from a result set
          *
@@ -56,18 +63,17 @@ namespace object {
         virtual std::shared_ptr<Object> CreateObjectFromStorage(uint64_t object_id){ return nullptr; }
         virtual std::shared_ptr<Object> CreateObjectFromTemplate(const std::string& template_name) { return nullptr; }
         uint32_t LookupType(uint64_t object_id) const;
-        virtual uint32_t GetType() const { return 0; }
-        const static uint32_t type;
-        virtual void RegisterEventHandlers(){}
 
+        virtual void RegisterEventHandlers(){}
+        void SetTreArchive(swganh::tre::TreArchive* tre_archive);
     protected:
         
 
         void LoadContainedObjects(const std::shared_ptr<Object>& object,
             const std::shared_ptr<sql::Statement>& statement);
-
+        
+        ObjectManager* object_manager_;
         anh::database::DatabaseManagerInterface* db_manager_;   
-        swganh::simulation::SimulationServiceInterface* simulation_service_;
         anh::EventDispatcher* event_dispatcher_;
     };
 

--- a/src/swganh/object/object_factory_interface.h
+++ b/src/swganh/object/object_factory_interface.h
@@ -68,8 +68,6 @@ namespace object {
          */
         virtual uint32_t LookupType(uint64_t object_id) const = 0;
 
-        virtual uint32_t GetType() const = 0;
-
     };
 
 }}  // namespace swganh::object

--- a/src/swganh/object/player/player.h
+++ b/src/swganh/object/player/player.h
@@ -288,11 +288,15 @@ struct PlayerWaypointSerializer {
     std::shared_ptr<swganh::object::waypoint::Waypoint> waypoint;
 };
 
+class PlayerFactory;
 class PlayerMessageBuilder;
 
 class Player : public swganh::object::Object
 {
 public:
+    typedef PlayerFactory FactoryType;
+    typedef PlayerMessageBuilder MessageBuilderType;
+
     Player();
     
     /**

--- a/src/swganh/object/player/player_factory.cc
+++ b/src/swganh/object/player/player_factory.cc
@@ -27,12 +27,9 @@ using namespace swganh::object;
 using namespace swganh::object::player;
 using namespace swganh::simulation;
 
-uint32_t PlayerFactory::GetType() const { return Player::type; }
-
 PlayerFactory::PlayerFactory(anh::database::DatabaseManagerInterface* db_manager,
-            swganh::simulation::SimulationServiceInterface* simulation_service,
             anh::EventDispatcher* event_dispatcher)
-    : ObjectFactory(db_manager, simulation_service, event_dispatcher)
+    : ObjectFactory(db_manager, event_dispatcher)
 {
     RegisterEventHandlers();
 }

--- a/src/swganh/object/player/player_factory.h
+++ b/src/swganh/object/player/player_factory.h
@@ -17,11 +17,6 @@ class ResultSet;
 }
 
 namespace swganh {
-namespace simulation {
-    class SimulationServiceInterface;
-}}  // namespace swganh::simulation
-
-namespace swganh {
 namespace object {
 namespace player {
     
@@ -30,7 +25,6 @@ namespace player {
     {
     public:
         PlayerFactory(anh::database::DatabaseManagerInterface* db_manager,
-            swganh::simulation::SimulationServiceInterface* simulation_service,
             anh::EventDispatcher* event_dispatcher);
 
         void LoadTemplates();
@@ -44,10 +38,7 @@ namespace player {
         std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObjectFromTemplate(const std::string& template_name);
-
-		virtual uint32_t GetType() const;
-        const static uint32_t type;
-
+        
         void RegisterEventHandlers();
     private:
         // Helpers

--- a/src/swganh/object/tangible/tangible.h
+++ b/src/swganh/object/tangible/tangible.h
@@ -81,6 +81,7 @@ struct ComponentCustomization
     uint32_t component_customization_crc;
 };
 
+class TangibleFactory;
 class TangibleMessageBuilder;
 
 /**
@@ -89,6 +90,9 @@ class TangibleMessageBuilder;
 class Tangible : public swganh::object::Object
 {
 public:
+    typedef TangibleFactory FactoryType;
+    typedef TangibleMessageBuilder MessageBuilderType;
+
     // TANO
     virtual uint32_t GetType() const { return Tangible::type; }
     const static uint32_t type = 0x54414e4f;

--- a/src/swganh/object/tangible/tangible_factory.cc
+++ b/src/swganh/object/tangible/tangible_factory.cc
@@ -23,12 +23,9 @@ using namespace swganh::object;
 using namespace swganh::object::tangible;
 using namespace swganh::simulation;
 
-uint32_t TangibleFactory::GetType() const { return Tangible::type; }
-
  TangibleFactory::TangibleFactory(anh::database::DatabaseManagerInterface* db_manager,
-            swganh::simulation::SimulationServiceInterface* simulation_service,
             anh::EventDispatcher* event_dispatcher)
-    : ObjectFactory(db_manager, simulation_service, event_dispatcher)
+    : ObjectFactory(db_manager, event_dispatcher)
 {
 }
 void TangibleFactory::LoadTemplates()

--- a/src/swganh/object/tangible/tangible_factory.h
+++ b/src/swganh/object/tangible/tangible_factory.h
@@ -13,11 +13,6 @@ namespace database {
 class DatabaseManagerInterface;
 }} // anh::database
 
-namespace swganh {
-namespace simulation {
-    class SimulationServiceInterface;
-}}  // namespace swganh::simulation
-
 namespace sql {
 class Statement;
 }
@@ -27,12 +22,12 @@ namespace object {
 namespace tangible {
 
     class Tangible;
-    class Tangible;
     class TangibleFactory : public swganh::object::ObjectFactory
     {
     public:
+        typedef Tangible ObjectType;
+
         TangibleFactory(anh::database::DatabaseManagerInterface* db_manager,
-            swganh::simulation::SimulationServiceInterface* simulation_service,
             anh::EventDispatcher* event_dispatcher);
         void LoadTemplates();
 
@@ -47,8 +42,6 @@ namespace tangible {
 
         std::shared_ptr<swganh::object::Object> CreateObjectFromTemplate(const std::string& template_name);
         
-        virtual uint32_t GetType() const;
-        const static uint32_t type;
         virtual void RegisterEventHandlers(){}
     private:
         std::unordered_map<std::string, std::shared_ptr<swganh::object::tangible::Tangible>>::iterator GetTemplateIter_(const std::string& template_name);

--- a/src/swganh/object/waypoint/waypoint_factory.cc
+++ b/src/swganh/object/waypoint/waypoint_factory.cc
@@ -28,8 +28,8 @@ using namespace swganh::simulation;
 using namespace swganh::messages::containers;
 
 WaypointFactory::WaypointFactory(DatabaseManagerInterface* db_manager,
-                             SimulationServiceInterface* simulation_service, EventDispatcher* event_dispatcher)
-    : ObjectFactory(db_manager, simulation_service, event_dispatcher)
+                                 EventDispatcher* event_dispatcher)
+    : ObjectFactory(db_manager, event_dispatcher)
 {
     RegisterEventHandlers();
 }

--- a/src/swganh/object/waypoint/waypoint_factory.h
+++ b/src/swganh/object/waypoint/waypoint_factory.h
@@ -13,12 +13,6 @@ class DatabaseManagerInterface;
 }} // anh::database
 
 namespace swganh {
-namespace simulation {
-    class SimulationServiceInterface;
-}}  // namespace swganh::simulation
-
-
-namespace swganh {
 namespace object {
 
 namespace player {class Player; }
@@ -29,7 +23,6 @@ namespace waypoint {
     {
     public:
         WaypointFactory(anh::database::DatabaseManagerInterface* db_manager,
-            swganh::simulation::SimulationServiceInterface* simulation_service,
             anh::EventDispatcher* event_dispatcher);
 
         void LoadTemplates();


### PR DESCRIPTION
This first entry in the equipment management improvements is a refactoring of the object type registration.

Before:

```
object_manager->RegisterObjectType(tangible::Tangible::type, make_shared<tangible::TangibleFactory>(db_manager, this, event_dispatcher));
object_manager->RegisterMessageBuilder(tangible::Tangible::type, make_shared<tangible::TangibleMessageBuilder>(event_dispatcher));
```

After:

```
object_manager->RegisterObjectType<tangible::Tangible>();
```
