### PR TITLE
Handlers are now wrapped in a try-catch

### DIFF
--- a/src/swganh/event_dispatcher.cc
+++ b/src/swganh/event_dispatcher.cc
@@ -2,6 +2,7 @@
 // See file LICENSE or go to http://swganh.com/LICENSE
 
 #include "event_dispatcher.h"
+#include "logger.h"
 
 #include <algorithm>
 
@@ -105,7 +106,14 @@ void EventDispatcher::InvokeCallbacks(const shared_ptr<EventInterface>& dispatch
             end(event_type_iter->second), 
             [&dispatch_event] (const EventHandlerList::value_type& handler) 
         {
-            handler.second(dispatch_event);
+            try
+            {
+                handler.second(dispatch_event);
+            }
+            catch(...)
+            {
+            	DLOG(warning) << "A handler callback caused an exception.";
+            }
         });
     }
 }


### PR DESCRIPTION
Handler calls are now wrapped in a try-catch to ensure that all handlers receive their callback in the case of an error.
