### PR TITLE
Clean up character creation a bit

### DIFF
--- a/data/scripts/character_create/create_starting_character.py
+++ b/data/scripts/character_create/create_starting_character.py
@@ -22,6 +22,7 @@ def CreateStartingCharacter(kernel, scale, base_model, customization, full_name,
 	# Create appropriate creature object...
 	species = GetSpecies(base_model)
 	creature = simulation.createObject(base_model.replace('player/', 'player/shared_'), ContainerPermission.CREATURE)
+	creature.scene_id = simulation.getSceneIdByName(startLoc.name)
 	creature.custom_name = full_name
 	creature.position = vector3(startLoc.x, startLoc.y, startLoc.z)
 	if customization:
@@ -44,7 +45,7 @@ def CreateStartingCharacter(kernel, scale, base_model, customization, full_name,
 	# Create mission
 	mission = simulation.createObject('object/tangible/mission_bag/shared_mission_bag.iff', ContainerPermission.CREATURE_CONTAINER)
 	# Create hair
-	hair = simulation.createObject(hair_model.replace('/hair_','/shared_hair_'))	
+	hair = simulation.createObject(hair_model.replace('/hair_','/shared_hair_'))
 	# Create Starting Items
 	startingItems = GetStartingItems(species, profession, gender)
 	# Add all sub objects to creature (parent)
@@ -54,7 +55,7 @@ def CreateStartingCharacter(kernel, scale, base_model, customization, full_name,
 	creature.add(creature, mission)
 	if (hair):
 		hair.setCustomizationFromInts(hair_customization)
-		creature.add(creature, hair)		
+		creature.add(creature, hair)
 	creature.add(creature, player)
 	# Now add the objects to the inventory
 	# Wearables get equipped
@@ -64,10 +65,9 @@ def CreateStartingCharacter(kernel, scale, base_model, customization, full_name,
 			creature.add(creature, item_obj)
 		else:
 			inventory.add(creature, item_obj)
-	
-	simulation.addObjectToScene(creature, startLoc.name)
+
 	return creature
-	
+
 def GetSpecies(base_model):
 	match = re.search('player/(.*)_', base_model)
 	return match.group(1)
@@ -94,9 +94,9 @@ def SetStartingStats(creature, s):
 	creature.setStatCurrent(STATS.MIND, s.mind[0])
 	creature.setStatCurrent(STATS.FOCUS, s.mind[1])
 	creature.setStatCurrent(STATS.WILLPOWER, s.mind[2])
-	
+
 def SetStartingSkills(creature, species, profession):
 	creature.addSkill(profession + '_novice')
 	for skill in baseSpeciesSkills[species]:
 		creature.addSkill(skill)
-		
+

--- a/data/sql/galaxy/procedures/sp_GetAttributes.sql
+++ b/data/sql/galaxy/procedures/sp_GetAttributes.sql
@@ -4,15 +4,12 @@
 
 DROP PROCEDURE IF EXISTS `sp_GetAttributes`;
 DELIMITER //
-CREATE PROCEDURE `sp_GetAttributes`(IN `iff_template` VARCHAR(255), IN `in_object_id` BIGINT)
+CREATE PROCEDURE `sp_GetAttributes`(IN `in_object_id` BIGINT)
 BEGIN
-	DECLARE iff_template_id INT;
-	SELECT swganh_static.iff_templates.id FROM swganh_static.iff_templates WHERE swganh_static.iff_templates.iff_template = iff_template INTO iff_template_id;
-	(select object_attributes.attribute_value, swganh_static.attributes.name
-		from object_attributes
-		left join swganh_static.attributes on (swganh_static.attributes.id = object_attributes.attribute_id)
-		where object_attributes.id = iff_template_id)
-;
+	select object_attributes.attribute_value, swganh_static.attributes.name
+	from object_attributes
+	left join swganh_static.attributes on (swganh_static.attributes.id = object_attributes.attribute_id)
+	where object_attributes.object_id = in_object_id;
 END//
 DELIMITER ;
 /*!40014 SET FOREIGN_KEY_CHECKS=1 */;

--- a/data/sql/galaxy/procedures/sp_GetCreature.sql
+++ b/data/sql/galaxy/procedures/sp_GetCreature.sql
@@ -9,26 +9,14 @@ DROP PROCEDURE IF EXISTS `sp_GetCreature`;
 DELIMITER //
 CREATE PROCEDURE `sp_GetCreature`(IN `object_id` BIGINT)
 BEGIN
-    call sp_GetTangible(object_id);
-
-    SELECT 
-        creature.*, 
-        mood.name as mood_animation, 
+    SELECT
+        creature.*,
+        mood.name as mood_animation,
         swganh_static.iff_templates.iff_template as disguise_template
-    FROM creature 
+    FROM creature
     LEFT JOIN swganh_static.iff_templates ON (creature.disguise_template_id = swganh_static.iff_templates.id)
     LEFT JOIN mood ON (creature.mood_id = mood.id)
     WHERE creature.id = object_id;
-
-	-- Get the buffs, and clear them out for next time
-	SELECT b.name, b.duration FROM buffs b
-	WHERE b.id = object_id;
-	DELETE FROM buffs WHERE id = object_id;
-	
-    call sp_GetCreatureSkills(object_id);
-    call sp_GetCreatureSkillMods(object_id);
-	call sp_GetCreatureSkillCommands(object_id);
-    call sp_GetContainedObjects(object_id);
 END//
 DELIMITER ;
 

--- a/data/sql/galaxy/procedures/sp_GetCreatureBuffs.sql
+++ b/data/sql/galaxy/procedures/sp_GetCreatureBuffs.sql
@@ -4,14 +4,14 @@
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
-DROP PROCEDURE IF EXISTS `sp_GetPlayer`;
+DROP PROCEDURE IF EXISTS `sp_GetCreatureBuffs`;
 
 DELIMITER //
-CREATE PROCEDURE `sp_GetPlayer`(IN `object_id` BIGINT)
+CREATE PROCEDURE `sp_GetCreatureBuffs`(IN `creature_id` BIGINT)
 BEGIN
-    SELECT *
-    FROM player
-    WHERE player.id = object_id ;
+    SELECT b.name, b.duration FROM buffs b
+    WHERE b.id = creature_id;
+    DELETE FROM buffs WHERE id = creature_id;
 END//
 DELIMITER ;
 

--- a/data/sql/galaxy/procedures/sp_GetIntangible.sql
+++ b/data/sql/galaxy/procedures/sp_GetIntangible.sql
@@ -9,7 +9,6 @@ DROP PROCEDURE IF EXISTS `sp_GetIntangible`;
 DELIMITER //
 CREATE PROCEDURE `sp_GetIntangible`(IN `object_id` BIGINT)
 BEGIN
-    call sp_GetObject(object_id);
     select i.stf_detail_file, i.stf_detail_string, i.generic_int from intangible i where i.id = object_id;
 END//
 DELIMITER ;

--- a/data/sql/galaxy/procedures/sp_GetPlayerBadges.sql
+++ b/data/sql/galaxy/procedures/sp_GetPlayerBadges.sql
@@ -4,14 +4,14 @@
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
-DROP PROCEDURE IF EXISTS `sp_GetPlayer`;
+DROP PROCEDURE IF EXISTS `sp_GetPlayerBadges`;
 
 DELIMITER //
-CREATE PROCEDURE `sp_GetPlayer`(IN `object_id` BIGINT)
+CREATE PROCEDURE `sp_GetPlayerBadges`(IN `object_id` BIGINT)
 BEGIN
-    SELECT *
-    FROM player
-    WHERE player.id = object_id ;
+    SELECT badge_id as badge
+    FROM player_badges
+    WHERE player_id = object_id;
 END//
 DELIMITER ;
 

--- a/data/sql/galaxy/procedures/sp_GetPlayerProfileFlags.sql
+++ b/data/sql/galaxy/procedures/sp_GetPlayerProfileFlags.sql
@@ -4,14 +4,15 @@
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
-DROP PROCEDURE IF EXISTS `sp_GetPlayer`;
+DROP PROCEDURE IF EXISTS `sp_GetPlayerProfileFlags`;
 
 DELIMITER //
-CREATE PROCEDURE `sp_GetPlayer`(IN `object_id` BIGINT)
+CREATE PROCEDURE `sp_GetPlayerProfileFlags`(IN `object_id` BIGINT)
 BEGIN
-    SELECT *
-    FROM player
-    WHERE player.id = object_id ;
+    SELECT profile_flag.flag
+    FROM profile_flag
+    LEFT JOIN players_profile_flags ON players_profile_flags.profile_flag_id = profile_flag.id
+    WHERE players_profile_flags.player_id = object_id;
 END//
 DELIMITER ;
 

--- a/data/sql/galaxy/procedures/sp_GetPlayerStatusFlags.sql
+++ b/data/sql/galaxy/procedures/sp_GetPlayerStatusFlags.sql
@@ -4,14 +4,15 @@
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 
-DROP PROCEDURE IF EXISTS `sp_GetPlayer`;
+DROP PROCEDURE IF EXISTS `sp_GetPlayerStatusFlags`;
 
 DELIMITER //
-CREATE PROCEDURE `sp_GetPlayer`(IN `object_id` BIGINT)
+CREATE PROCEDURE `sp_GetPlayerStatusFlags`(IN `object_id` BIGINT)
 BEGIN
-    SELECT *
-    FROM player
-    WHERE player.id = object_id ;
+    SELECT status_flag.flag
+    FROM status_flag
+    LEFT JOIN players_status_flags ON players_status_flags.status_flag_id = status_flag.id
+    WHERE players_status_flags.player_id = object_id;
 END//
 DELIMITER ;
 

--- a/data/sql/galaxy/procedures/sp_GetTangible.sql
+++ b/data/sql/galaxy/procedures/sp_GetTangible.sql
@@ -9,10 +9,9 @@ DROP PROCEDURE IF EXISTS `sp_GetTangible`;
 DELIMITER //
 CREATE PROCEDURE `sp_GetTangible`(IN `object_id` BIGINT)
 BEGIN
-    call sp_GetObject(object_id);
-    select t.customization, t.options_bitmask, t.incap_timer, 
-        t.condition_damage, t.max_condition, t.is_static 
-    from tangible t 
+    select t.customization, t.options_bitmask, t.incap_timer,
+        t.condition_damage, t.max_condition, t.is_static
+    from tangible t
     where t.id = object_id;
 END//
 DELIMITER ;

--- a/data/sql/galaxy/procedures/sp_PersistAttribute.sql
+++ b/data/sql/galaxy/procedures/sp_PersistAttribute.sql
@@ -11,7 +11,7 @@ DECLARE id_exists BIGINT;
 select id from swganh_static.attributes sa where sa.name = in_attribute_name limit 1 into in_attribute_id ;
 select object_id from object_attributes where object_id = in_object_id and attribute_id = in_attribute_id limit 1 into id_exists;
 if id_exists <> 0 then
-	update object_attributes set object_id = in_object_id, attribute_id = in_attribute_id, attribute_value = in_attribute_value;
+	update object_attributes set attribute_value = in_attribute_value where object_id = in_object_id and attribute_id = in_attribute_id;
 else
 	insert into object_attributes (object_id, attribute_id, attribute_value) values (in_object_id, in_attribute_id, in_attribute_value);
 end if;

--- a/data/sql/galaxy/procedures/sp_PersistAttribute.sql
+++ b/data/sql/galaxy/procedures/sp_PersistAttribute.sql
@@ -7,9 +7,9 @@ DELIMITER //
 CREATE PROCEDURE `sp_PersistAttribute`(IN `in_object_id` BIGINT, IN `in_attribute_name` VARCHAR(255), IN `in_attribute_value` VARCHAR(255))
 BEGIN
 DECLARE in_attribute_id INT;
-DECLARE id_exists INT;
+DECLARE id_exists BIGINT;
 select id from swganh_static.attributes sa where sa.name = in_attribute_name limit 1 into in_attribute_id ;
-select id from object_attributes where object_id = in_object_id and attribute_id = in_attribute_id limit 1 into id_exists;
+select object_id from object_attributes where object_id = in_object_id and attribute_id = in_attribute_id limit 1 into id_exists;
 if id_exists <> 0 then
 	update object_attributes set object_id = in_object_id, attribute_id = in_attribute_id, attribute_value = in_attribute_value;
 else

--- a/data/sql/galaxy/scripts/object_attributes.sql
+++ b/data/sql/galaxy/scripts/object_attributes.sql
@@ -13,14 +13,13 @@
 -- Dumping structure for table galaxy.object_attributes
 DROP TABLE IF EXISTS `object_attributes`;
 CREATE TABLE IF NOT EXISTS `object_attributes` (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
   `object_id` bigint(20) DEFAULT NULL,
   `attribute_id` int(11) unsigned DEFAULT NULL,
   `attribute_value` varchar(255) DEFAULT '',
-  PRIMARY KEY (`id`),
+  PRIMARY KEY (`object_id`, `attribute_id`),
   KEY `FK_object_attributes_swganh_static.attributes` (`attribute_id`),
   CONSTRAINT `FK_object_attributes_swganh_static.attributes` FOREIGN KEY (`attribute_id`) REFERENCES `swganh_static`.`attributes` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
-) ENGINE=InnoDB AUTO_INCREMENT=32814 DEFAULT CHARSET=utf8 COMMENT='stores attributes for objects';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='stores attributes for objects';
 
 DELETE FROM `object_attributes`;
 

--- a/data/sql/swganh_static/scripts/attributes.sql
+++ b/data/sql/swganh_static/scripts/attributes.sql
@@ -1378,7 +1378,12 @@ INSERT INTO `attributes` (`id`, `name`, `internal`, `attribute_internal_descript
 	(2083, 'cat_armor_encumbrance.armor_action_encumbrance', 0, 'Action:', 11, 0),
 	(2084, 'cat_armor_encumbrance.armor_mind_encumbrance', 0, 'Mind:', 11, 0),
 	(2085, 'needs_setup', 1, 'schem_tool use only', 0, 0),
-	(2086, 'radial_filename', 0, 'Script filename for this object.', 0, 0);
+	(2086, 'radial_filename', 0, 'Script filename for this object.', 0, 0),
+	(2087, 'pcd_id', 0, 'Id of the player control device for a vehicle', 0, 0),
+	(2088, 'deed_mobile', 0, 'Deed for a mobile object.', 0, 0),
+	(2089, 'is_mount', 0, 'If an object has this attribute it is a mount.', 0, 0),
+	(2090, 'mobile_id', 0, 'The id of the mobile object associated with this object', 0, 0),
+	(2091, 'deed_pcd', 0, 'Deed for the pcd object', 0, 0);
 /*!40000 ALTER TABLE `attributes` ENABLE KEYS */;
 /*!40014 SET FOREIGN_KEY_CHECKS=1 */;
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;

--- a/src/swganh/thread_pool.h
+++ b/src/swganh/thread_pool.h
@@ -13,6 +13,8 @@
 
 #include <boost/noncopyable.hpp>
 
+#include "swganh/logger.h"
+
 namespace swganh {
 
     class ThreadPool : private boost::noncopyable
@@ -32,7 +34,13 @@ namespace swganh {
                 std::unique_lock<std::mutex> lock(queue_mutex_);
 
                 tasks_.emplace_back([wrapped_task] () {
-                    (*wrapped_task)();
+                    try {
+                        (*wrapped_task)();
+                    } 
+                    catch(std::exception& e)
+                    {
+                        LOG(error) << e.what();
+                    }
                 });
             }
 

--- a/src/swganh/thread_pool.h
+++ b/src/swganh/thread_pool.h
@@ -22,9 +22,9 @@ namespace swganh {
         ~ThreadPool();
 
         template<typename T>
-        std::future<typename std::result_of<T()>::type> Schedule(T&& task)
+        auto Schedule(T&& task) -> std::future<decltype(task())>
         {
-            auto wrapped_task = std::make_shared<std::packaged_task<typename std::result_of<T()>::type()>>(std::move(task));
+            auto wrapped_task = std::make_shared<std::packaged_task<decltype(task())()>>(std::move(task));
 
             auto result_future = wrapped_task->get_future();
 

--- a/src/swganh_core/object/building/building_factory.cc
+++ b/src/swganh_core/object/building/building_factory.cc
@@ -20,7 +20,11 @@ using namespace swganh::object;
 
 BuildingFactory::BuildingFactory(swganh::app::SwganhKernel* kernel)
 	: TangibleFactory(kernel)
+{}
+
+void BuildingFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    TangibleFactory::LoadFromStorage(connection, object);
 }
 
 std::shared_ptr<swganh::object::Object> BuildingFactory::CreateObject()

--- a/src/swganh_core/object/building/building_factory.h
+++ b/src/swganh_core/object/building/building_factory.h
@@ -20,6 +20,8 @@ namespace object {
 
         BuildingFactory(swganh::app::SwganhKernel* kernel);
 		
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
+
 		virtual void PersistChangedObjects(){}
 		virtual void RegisterEventHandlers(){}
 

--- a/src/swganh_core/object/cell/cell_factory.cc
+++ b/src/swganh_core/object/cell/cell_factory.cc
@@ -18,8 +18,12 @@ using namespace std;
 using namespace swganh::object;
 
 CellFactory::CellFactory(swganh::app::SwganhKernel* kernel)
-			: IntangibleFactory(kernel)
+    : IntangibleFactory(kernel)
+{}
+
+void CellFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    IntangibleFactory::LoadFromStorage(connection, object);
 }
 
 void CellFactory::RegisterEventHandlers()
@@ -69,12 +73,6 @@ uint32_t CellFactory::PersistObject(const shared_ptr<Object>& object, bool persi
 void CellFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> CellFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-	//TODO: Use the db to fetch me
-    return make_shared<Cell>();
 }
 
 shared_ptr<Object> CellFactory::CreateObject()

--- a/src/swganh_core/object/cell/cell_factory.cc
+++ b/src/swganh_core/object/cell/cell_factory.cc
@@ -50,8 +50,9 @@ uint32_t CellFactory::PersistObject(const shared_ptr<Object>& object, bool persi
 {
 	// Persist Intangible and Base Object First
     uint32_t counter = 1;
-	if (persist_inherited)
-		IntangibleFactory::PersistObject(object, persist_inherited);
+	
+    IntangibleFactory::PersistObject(object, persist_inherited);
+
 	try 
     {
 		auto conn = GetDatabaseManager()->getConnection("galaxy");

--- a/src/swganh_core/object/cell/cell_factory.h
+++ b/src/swganh_core/object/cell/cell_factory.h
@@ -15,11 +15,12 @@ namespace object {
 		typedef Cell ObjectType;
 
         CellFactory(swganh::app::SwganhKernel* kernel);
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 		virtual void PersistChangedObjects();
 		void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
-		std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
 

--- a/src/swganh_core/object/creature/creature_factory.cc
+++ b/src/swganh_core/object/creature/creature_factory.cc
@@ -191,8 +191,9 @@ void CreatureFactory::PersistChangedObjects()
 uint32_t CreatureFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
     uint32_t counter = 1;
-	if (persist_inherited)
-		TangibleFactory::PersistObject(object, persist_inherited);
+
+	TangibleFactory::PersistObject(object, persist_inherited);
+
 	// Now for the biggy
     try
     {	

--- a/src/swganh_core/object/creature/creature_factory.cc
+++ b/src/swganh_core/object/creature/creature_factory.cc
@@ -27,8 +27,109 @@ using namespace swganh::simulation;
 
 CreatureFactory::CreatureFactory(swganh::app::SwganhKernel* kernel)
     : TangibleFactory(kernel)
+{}
+
+void CreatureFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    TangibleFactory::LoadFromStorage(connection, object);
+
+    auto creature = std::dynamic_pointer_cast<Creature>(object);
+    if(!creature)
+    {
+        throw InvalidObject("Object requested for loading is not Intangible");
+    }
+
+    auto statement = std::shared_ptr<sql::PreparedStatement>
+        (connection->prepareStatement("CALL sp_GetTangible(?);"));
+    
+    statement->setUInt64(1, creature->GetObjectId());
+
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
+    while (result->next())
+    {
+        creature->SetOwnerId(result->getUInt64("owner_id"));
+        creature->SetListenToId(result->getUInt64("musician_id"));
+        creature->SetBankCredits(result->getUInt("bank_credits"));
+        creature->SetCashCredits(result->getUInt("cash_credits"));
+        creature->SetPosture((Posture)result->getUInt("posture"));
+        creature->SetFactionRank(result->getUInt("faction_rank"));
+        creature->SetScale(static_cast<float>(result->getDouble("scale")));
+        creature->SetBattleFatigue(result->getUInt("battle_fatigue"));
+        creature->SetStateBitmask(result->getUInt("state"));
+        creature->SetAccelerationMultiplierBase(static_cast<float>(result->getDouble("acceleration_base")));
+        creature->SetAccelerationMultiplierModifier(static_cast<float>(result->getDouble("acceleration_modifier")));
+        creature->SetSpeedMultiplierBase(static_cast<float>(result->getDouble("speed_base")));
+        creature->SetSpeedMultiplierModifier(static_cast<float>(result->getDouble("speed_modifier")));
+        creature->SetRunSpeed(static_cast<float>(result->getDouble("run_speed")));
+        creature->SetSlopeModifierAngle(static_cast<float>(result->getDouble("slope_modifier_angle")));
+        creature->SetSlopeModifierPercent(static_cast<float>(result->getDouble("slope_modifier_percent")));
+        creature->SetWalkingSpeed(static_cast<float>(result->getDouble("walking_speed")));
+        creature->SetTurnRadius(static_cast<float>(result->getDouble("turn_radius")));
+        creature->SetWaterModifierPercent(static_cast<float>(result->getDouble("water_modifier_percent")));
+        creature->SetCombatLevel(result->getUInt("combat_level"));
+        creature->SetAnimation(result->getString("animation"));
+        creature->SetMoodAnimation(result->getString("mood_animation"));
+        
+        /// @TODO: Find a better place for this.
+        if (creature->GetMoodAnimation().compare("none") == 0)
+        {
+            creature->SetMoodAnimation("neutral");
+        }
+
+        creature->SetGroupId(result->getUInt64("group_id"));
+        creature->SetGuildId(result->getUInt("guild_id"));
+        creature->SetWeaponId(result->getUInt64("weapon_id"));
+        creature->SetMoodId(result->getUInt("mood_id"));
+        creature->SetPerformanceId(result->getUInt("performance_id"));
+        creature->SetDisguise(result->getString("disguise_template"));
+        
+        creature->SetStatCurrent(HEALTH, result->getUInt("current_health"));
+        creature->SetStatCurrent(STRENGTH, result->getUInt("current_strength"));
+        creature->SetStatCurrent(CONSTITUTION, result->getUInt("current_constitution"));
+        creature->SetStatCurrent(ACTION, result->getUInt("current_action"));
+        creature->SetStatCurrent(QUICKNESS, result->getUInt("current_quickness"));
+        creature->SetStatCurrent(STAMINA, result->getUInt("current_stamina"));
+        creature->SetStatCurrent(MIND, result->getUInt("current_mind"));
+        creature->SetStatCurrent(FOCUS, result->getUInt("current_focus"));
+        creature->SetStatCurrent(WILLPOWER, result->getUInt("current_willpower"));
+        
+        creature->SetStatMax(HEALTH, result->getUInt("max_health"));
+        creature->SetStatMax(STRENGTH, result->getUInt("max_strength"));
+        creature->SetStatMax(CONSTITUTION, result->getUInt("max_constitution"));
+        creature->SetStatMax(ACTION, result->getUInt("max_action"));
+        creature->SetStatMax(QUICKNESS, result->getUInt("max_quickness"));
+        creature->SetStatMax(STAMINA, result->getUInt("max_stamina"));
+        creature->SetStatMax(MIND, result->getUInt("max_mind"));
+        creature->SetStatMax(FOCUS, result->getUInt("max_focus"));
+        creature->SetStatMax(WILLPOWER, result->getUInt("max_willpower"));
+        
+        creature->SetStatWound(HEALTH, result->getUInt("health_wounds"));
+        creature->SetStatWound(STRENGTH, result->getUInt("strength_wounds"));
+        creature->SetStatWound(CONSTITUTION, result->getUInt("constitution_wounds"));
+        creature->SetStatWound(ACTION, result->getUInt("action_wounds"));
+        creature->SetStatWound(QUICKNESS, result->getUInt("quickness_wounds"));
+        creature->SetStatWound(STAMINA, result->getUInt("stamina_wounds"));
+        creature->SetStatWound(MIND, result->getUInt("mind_wounds"));
+        creature->SetStatWound(FOCUS, result->getUInt("focus_wounds"));
+        creature->SetStatWound(WILLPOWER, result->getUInt("willpower_wounds"));
+        
+        creature->SetStatBase(HEALTH, result->getUInt("health_wounds"));
+        creature->SetStatBase(STRENGTH, result->getUInt("strength_wounds"));
+        creature->SetStatBase(CONSTITUTION, result->getUInt("constitution_wounds"));
+        creature->SetStatBase(ACTION, result->getUInt("action_wounds"));
+        creature->SetStatBase(QUICKNESS, result->getUInt("quickness_wounds"));
+        creature->SetStatBase(STAMINA, result->getUInt("stamina_wounds"));
+        creature->SetStatBase(MIND, result->getUInt("mind_wounds"));
+        creature->SetStatBase(FOCUS, result->getUInt("focus_wounds"));
+        creature->SetStatBase(WILLPOWER, result->getUInt("willpower_wounds"));
+    }
+        
+    LoadBuffs_(connection, creature);
+    LoadSkills_(connection, creature);
+    LoadSkillMods_(connection, creature);
+    LoadSkillCommands_(connection, creature);
 }
+
 void CreatureFactory::RegisterEventHandlers()
 {
 	GetEventDispatcher()->Subscribe("Creature::Bank", std::bind(&CreatureFactory::PersistHandler, this, std::placeholders::_1));
@@ -377,5 +478,61 @@ void CreatureFactory::LoadSkillCommands_(
         {
            creature->AddSkillCommand(make_pair(result->getInt("id"), result->getString("name")));
         }
+    }
+}
+
+void CreatureFactory::LoadSkills_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature)
+{
+    auto statement = std::shared_ptr<sql::PreparedStatement>
+        (connection->prepareStatement("CALL sp_GetCreatureSkills(?);"));
+    
+    statement->setUInt64(1, creature->GetObjectId());
+
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
+    while (result->next())
+    {
+        creature->AddSkill(result->getString("name"));
+    }
+}
+
+void CreatureFactory::LoadSkillMods_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature)
+{
+    auto statement = std::shared_ptr<sql::PreparedStatement>
+        (connection->prepareStatement("CALL sp_GetCreatureSkillMods(?);"));
+    
+    statement->setUInt64(1, creature->GetObjectId());
+
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
+    while (result->next())
+    {
+        creature->AddSkillMod(SkillMod(result->getString("name"), result->getUInt("value"), 0));	
+    }
+}
+
+void CreatureFactory::LoadSkillCommands_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature)
+{
+    auto statement = std::shared_ptr<sql::PreparedStatement>
+        (connection->prepareStatement("CALL sp_GetCreatureSkillCommands(?);"));
+    
+    statement->setUInt64(1, creature->GetObjectId());
+
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
+    while (result->next())
+    {
+        creature->AddSkillCommand(std::make_pair(result->getInt("id"), result->getString("name")));
+    }
+}
+
+void CreatureFactory::LoadBuffs_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<swganh::object::Creature>& creature)
+{
+    auto statement = std::shared_ptr<sql::PreparedStatement>
+        (connection->prepareStatement("CALL sp_GetCreatureBuffs(?);"));
+    
+    statement->setUInt64(1, creature->GetObjectId());
+
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
+    while (result->next())
+    {
+        creature->AddBuff(result->getString("name"), result->getUInt("duration"));
     }
 }

--- a/src/swganh_core/object/creature/creature_factory.cc
+++ b/src/swganh_core/object/creature/creature_factory.cc
@@ -39,91 +39,94 @@ void CreatureFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& co
         throw InvalidObject("Object requested for loading is not Intangible");
     }
 
-    auto statement = std::shared_ptr<sql::PreparedStatement>
-        (connection->prepareStatement("CALL sp_GetTangible(?);"));
+    auto statement = std::unique_ptr<sql::PreparedStatement>
+        (connection->prepareStatement("CALL sp_GetCreature(?);"));
     
     statement->setUInt64(1, creature->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
     {
-        creature->SetOwnerId(result->getUInt64("owner_id"));
-        creature->SetListenToId(result->getUInt64("musician_id"));
-        creature->SetBankCredits(result->getUInt("bank_credits"));
-        creature->SetCashCredits(result->getUInt("cash_credits"));
-        creature->SetPosture((Posture)result->getUInt("posture"));
-        creature->SetFactionRank(result->getUInt("faction_rank"));
-        creature->SetScale(static_cast<float>(result->getDouble("scale")));
-        creature->SetBattleFatigue(result->getUInt("battle_fatigue"));
-        creature->SetStateBitmask(result->getUInt("state"));
-        creature->SetAccelerationMultiplierBase(static_cast<float>(result->getDouble("acceleration_base")));
-        creature->SetAccelerationMultiplierModifier(static_cast<float>(result->getDouble("acceleration_modifier")));
-        creature->SetSpeedMultiplierBase(static_cast<float>(result->getDouble("speed_base")));
-        creature->SetSpeedMultiplierModifier(static_cast<float>(result->getDouble("speed_modifier")));
-        creature->SetRunSpeed(static_cast<float>(result->getDouble("run_speed")));
-        creature->SetSlopeModifierAngle(static_cast<float>(result->getDouble("slope_modifier_angle")));
-        creature->SetSlopeModifierPercent(static_cast<float>(result->getDouble("slope_modifier_percent")));
-        creature->SetWalkingSpeed(static_cast<float>(result->getDouble("walking_speed")));
-        creature->SetTurnRadius(static_cast<float>(result->getDouble("turn_radius")));
-        creature->SetWaterModifierPercent(static_cast<float>(result->getDouble("water_modifier_percent")));
-        creature->SetCombatLevel(result->getUInt("combat_level"));
-        creature->SetAnimation(result->getString("animation"));
-        creature->SetMoodAnimation(result->getString("mood_animation"));
-        
-        /// @TODO: Find a better place for this.
-        if (creature->GetMoodAnimation().compare("none") == 0)
+        while (result->next())
         {
-            creature->SetMoodAnimation("neutral");
-        }
+            creature->SetOwnerId(result->getUInt64("owner_id"));
+            creature->SetListenToId(result->getUInt64("musician_id"));
+            creature->SetBankCredits(result->getUInt("bank_credits"));
+            creature->SetCashCredits(result->getUInt("cash_credits"));
+            creature->SetPosture((Posture)result->getUInt("posture"));
+            creature->SetFactionRank(result->getUInt("faction_rank"));
+            creature->SetScale(static_cast<float>(result->getDouble("scale")));
+            creature->SetBattleFatigue(result->getUInt("battle_fatigue"));
+            creature->SetStateBitmask(result->getUInt("state"));
+            creature->SetAccelerationMultiplierBase(static_cast<float>(result->getDouble("acceleration_base")));
+            creature->SetAccelerationMultiplierModifier(static_cast<float>(result->getDouble("acceleration_modifier")));
+            creature->SetSpeedMultiplierBase(static_cast<float>(result->getDouble("speed_base")));
+            creature->SetSpeedMultiplierModifier(static_cast<float>(result->getDouble("speed_modifier")));
+            creature->SetRunSpeed(static_cast<float>(result->getDouble("run_speed")));
+            creature->SetSlopeModifierAngle(static_cast<float>(result->getDouble("slope_modifier_angle")));
+            creature->SetSlopeModifierPercent(static_cast<float>(result->getDouble("slope_modifier_percent")));
+            creature->SetWalkingSpeed(static_cast<float>(result->getDouble("walking_speed")));
+            creature->SetTurnRadius(static_cast<float>(result->getDouble("turn_radius")));
+            creature->SetWaterModifierPercent(static_cast<float>(result->getDouble("water_modifier_percent")));
+            creature->SetCombatLevel(result->getUInt("combat_level"));
+            creature->SetAnimation(result->getString("animation"));
+            creature->SetMoodAnimation(result->getString("mood_animation"));
+            
+            /// @TODO: Find a better place for this.
+            if (creature->GetMoodAnimation().compare("none") == 0)
+            {
+                creature->SetMoodAnimation("neutral");
+            }
 
-        creature->SetGroupId(result->getUInt64("group_id"));
-        creature->SetGuildId(result->getUInt("guild_id"));
-        creature->SetWeaponId(result->getUInt64("weapon_id"));
-        creature->SetMoodId(result->getUInt("mood_id"));
-        creature->SetPerformanceId(result->getUInt("performance_id"));
-        creature->SetDisguise(result->getString("disguise_template"));
-        
-        creature->SetStatCurrent(HEALTH, result->getUInt("current_health"));
-        creature->SetStatCurrent(STRENGTH, result->getUInt("current_strength"));
-        creature->SetStatCurrent(CONSTITUTION, result->getUInt("current_constitution"));
-        creature->SetStatCurrent(ACTION, result->getUInt("current_action"));
-        creature->SetStatCurrent(QUICKNESS, result->getUInt("current_quickness"));
-        creature->SetStatCurrent(STAMINA, result->getUInt("current_stamina"));
-        creature->SetStatCurrent(MIND, result->getUInt("current_mind"));
-        creature->SetStatCurrent(FOCUS, result->getUInt("current_focus"));
-        creature->SetStatCurrent(WILLPOWER, result->getUInt("current_willpower"));
-        
-        creature->SetStatMax(HEALTH, result->getUInt("max_health"));
-        creature->SetStatMax(STRENGTH, result->getUInt("max_strength"));
-        creature->SetStatMax(CONSTITUTION, result->getUInt("max_constitution"));
-        creature->SetStatMax(ACTION, result->getUInt("max_action"));
-        creature->SetStatMax(QUICKNESS, result->getUInt("max_quickness"));
-        creature->SetStatMax(STAMINA, result->getUInt("max_stamina"));
-        creature->SetStatMax(MIND, result->getUInt("max_mind"));
-        creature->SetStatMax(FOCUS, result->getUInt("max_focus"));
-        creature->SetStatMax(WILLPOWER, result->getUInt("max_willpower"));
-        
-        creature->SetStatWound(HEALTH, result->getUInt("health_wounds"));
-        creature->SetStatWound(STRENGTH, result->getUInt("strength_wounds"));
-        creature->SetStatWound(CONSTITUTION, result->getUInt("constitution_wounds"));
-        creature->SetStatWound(ACTION, result->getUInt("action_wounds"));
-        creature->SetStatWound(QUICKNESS, result->getUInt("quickness_wounds"));
-        creature->SetStatWound(STAMINA, result->getUInt("stamina_wounds"));
-        creature->SetStatWound(MIND, result->getUInt("mind_wounds"));
-        creature->SetStatWound(FOCUS, result->getUInt("focus_wounds"));
-        creature->SetStatWound(WILLPOWER, result->getUInt("willpower_wounds"));
-        
-        creature->SetStatBase(HEALTH, result->getUInt("health_wounds"));
-        creature->SetStatBase(STRENGTH, result->getUInt("strength_wounds"));
-        creature->SetStatBase(CONSTITUTION, result->getUInt("constitution_wounds"));
-        creature->SetStatBase(ACTION, result->getUInt("action_wounds"));
-        creature->SetStatBase(QUICKNESS, result->getUInt("quickness_wounds"));
-        creature->SetStatBase(STAMINA, result->getUInt("stamina_wounds"));
-        creature->SetStatBase(MIND, result->getUInt("mind_wounds"));
-        creature->SetStatBase(FOCUS, result->getUInt("focus_wounds"));
-        creature->SetStatBase(WILLPOWER, result->getUInt("willpower_wounds"));
-    }
-        
+            creature->SetGroupId(result->getUInt64("group_id"));
+            creature->SetGuildId(result->getUInt("guild_id"));
+            creature->SetWeaponId(result->getUInt64("weapon_id"));
+            creature->SetMoodId(result->getUInt("mood_id"));
+            creature->SetPerformanceId(result->getUInt("performance_id"));
+            creature->SetDisguise(result->getString("disguise_template"));
+            
+            creature->SetStatCurrent(HEALTH, result->getUInt("current_health"));
+            creature->SetStatCurrent(STRENGTH, result->getUInt("current_strength"));
+            creature->SetStatCurrent(CONSTITUTION, result->getUInt("current_constitution"));
+            creature->SetStatCurrent(ACTION, result->getUInt("current_action"));
+            creature->SetStatCurrent(QUICKNESS, result->getUInt("current_quickness"));
+            creature->SetStatCurrent(STAMINA, result->getUInt("current_stamina"));
+            creature->SetStatCurrent(MIND, result->getUInt("current_mind"));
+            creature->SetStatCurrent(FOCUS, result->getUInt("current_focus"));
+            creature->SetStatCurrent(WILLPOWER, result->getUInt("current_willpower"));
+            
+            creature->SetStatMax(HEALTH, result->getUInt("max_health"));
+            creature->SetStatMax(STRENGTH, result->getUInt("max_strength"));
+            creature->SetStatMax(CONSTITUTION, result->getUInt("max_constitution"));
+            creature->SetStatMax(ACTION, result->getUInt("max_action"));
+            creature->SetStatMax(QUICKNESS, result->getUInt("max_quickness"));
+            creature->SetStatMax(STAMINA, result->getUInt("max_stamina"));
+            creature->SetStatMax(MIND, result->getUInt("max_mind"));
+            creature->SetStatMax(FOCUS, result->getUInt("max_focus"));
+            creature->SetStatMax(WILLPOWER, result->getUInt("max_willpower"));
+            
+            creature->SetStatWound(HEALTH, result->getUInt("health_wounds"));
+            creature->SetStatWound(STRENGTH, result->getUInt("strength_wounds"));
+            creature->SetStatWound(CONSTITUTION, result->getUInt("constitution_wounds"));
+            creature->SetStatWound(ACTION, result->getUInt("action_wounds"));
+            creature->SetStatWound(QUICKNESS, result->getUInt("quickness_wounds"));
+            creature->SetStatWound(STAMINA, result->getUInt("stamina_wounds"));
+            creature->SetStatWound(MIND, result->getUInt("mind_wounds"));
+            creature->SetStatWound(FOCUS, result->getUInt("focus_wounds"));
+            creature->SetStatWound(WILLPOWER, result->getUInt("willpower_wounds"));
+            
+            creature->SetStatBase(HEALTH, result->getUInt("health_wounds"));
+            creature->SetStatBase(STRENGTH, result->getUInt("strength_wounds"));
+            creature->SetStatBase(CONSTITUTION, result->getUInt("constitution_wounds"));
+            creature->SetStatBase(ACTION, result->getUInt("action_wounds"));
+            creature->SetStatBase(QUICKNESS, result->getUInt("quickness_wounds"));
+            creature->SetStatBase(STAMINA, result->getUInt("stamina_wounds"));
+            creature->SetStatBase(MIND, result->getUInt("mind_wounds"));
+            creature->SetStatBase(FOCUS, result->getUInt("focus_wounds"));
+            creature->SetStatBase(WILLPOWER, result->getUInt("willpower_wounds"));
+        }
+    } while(statement->getMoreResults());
+
     LoadBuffs_(connection, creature);
     LoadSkills_(connection, creature);
     LoadSkillMods_(connection, creature);
@@ -285,200 +288,9 @@ void CreatureFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 	ObjectFactory::DeleteObjectFromStorage(object);
 }
 
-shared_ptr<Object> CreatureFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    auto creature = make_shared<Creature>();
-    creature->SetObjectId(object_id);
-    try {
-        auto conn = GetDatabaseManager()->getConnection("galaxy");
-        auto statement = shared_ptr<sql::Statement>(conn->createStatement());
-        unique_ptr<sql::ResultSet> result;
-        stringstream ss;
-        ss << "CALL sp_GetCreature(" << object_id << ");" ;
-        statement->execute(ss.str());
-        CreateTangible(creature, statement);
-        
-        if (statement->getMoreResults())
-        {
-            result.reset(statement->getResultSet());
-            while (result->next())
-            {
-                creature->SetOwnerId(result->getUInt64("owner_id"));
-                creature->SetListenToId(result->getUInt64("musician_id"));
-                creature->SetBankCredits(result->getUInt("bank_credits"));
-                creature->SetCashCredits(result->getUInt("cash_credits"));
-                creature->SetPosture((Posture)result->getUInt("posture"));
-                creature->SetFactionRank(result->getUInt("faction_rank"));
-                creature->SetScale(static_cast<float>(result->getDouble("scale")));
-                creature->SetBattleFatigue(result->getUInt("battle_fatigue"));
-                creature->SetStateBitmask(result->getUInt("state"));
-                creature->SetAccelerationMultiplierBase(static_cast<float>(result->getDouble("acceleration_base")));
-                creature->SetAccelerationMultiplierModifier(static_cast<float>(result->getDouble("acceleration_modifier")));
-                creature->SetSpeedMultiplierBase(static_cast<float>(result->getDouble("speed_base")));
-                creature->SetSpeedMultiplierModifier(static_cast<float>(result->getDouble("speed_modifier")));
-                creature->SetRunSpeed(static_cast<float>(result->getDouble("run_speed")));
-                creature->SetSlopeModifierAngle(static_cast<float>(result->getDouble("slope_modifier_angle")));
-                creature->SetSlopeModifierPercent(static_cast<float>(result->getDouble("slope_modifier_percent")));
-                creature->SetWalkingSpeed(static_cast<float>(result->getDouble("walking_speed")));
-                creature->SetTurnRadius(static_cast<float>(result->getDouble("turn_radius")));
-                creature->SetWaterModifierPercent(static_cast<float>(result->getDouble("water_modifier_percent")));
-                creature->SetCombatLevel(result->getUInt("combat_level"));
-                creature->SetAnimation(result->getString("animation"));
-                creature->SetMoodAnimation(result->getString("mood_animation"));
-
-                /// @TODO: Find a better place for this.
-                if (creature->GetMoodAnimation().compare("none") == 0)
-                {
-                    creature->SetMoodAnimation("neutral");
-                }
-
-                creature->SetGroupId(result->getUInt64("group_id"));
-                creature->SetGuildId(result->getUInt("guild_id"));
-                creature->SetWeaponId(result->getUInt64("weapon_id"));
-                creature->SetMoodId(result->getUInt("mood_id"));
-                creature->SetPerformanceId(result->getUInt("performance_id"));
-                creature->SetDisguise(result->getString("disguise_template"));
-
-                creature->SetStatCurrent(HEALTH, result->getUInt("current_health"));
-                creature->SetStatCurrent(STRENGTH, result->getUInt("current_strength"));
-                creature->SetStatCurrent(CONSTITUTION, result->getUInt("current_constitution"));
-                creature->SetStatCurrent(ACTION, result->getUInt("current_action"));
-                creature->SetStatCurrent(QUICKNESS, result->getUInt("current_quickness"));
-                creature->SetStatCurrent(STAMINA, result->getUInt("current_stamina"));
-                creature->SetStatCurrent(MIND, result->getUInt("current_mind"));
-                creature->SetStatCurrent(FOCUS, result->getUInt("current_focus"));
-                creature->SetStatCurrent(WILLPOWER, result->getUInt("current_willpower"));
-
-                creature->SetStatMax(HEALTH, result->getUInt("max_health"));
-                creature->SetStatMax(STRENGTH, result->getUInt("max_strength"));
-                creature->SetStatMax(CONSTITUTION, result->getUInt("max_constitution"));
-                creature->SetStatMax(ACTION, result->getUInt("max_action"));
-                creature->SetStatMax(QUICKNESS, result->getUInt("max_quickness"));
-                creature->SetStatMax(STAMINA, result->getUInt("max_stamina"));
-                creature->SetStatMax(MIND, result->getUInt("max_mind"));
-                creature->SetStatMax(FOCUS, result->getUInt("max_focus"));
-                creature->SetStatMax(WILLPOWER, result->getUInt("max_willpower"));
-
-                creature->SetStatWound(HEALTH, result->getUInt("health_wounds"));
-                creature->SetStatWound(STRENGTH, result->getUInt("strength_wounds"));
-                creature->SetStatWound(CONSTITUTION, result->getUInt("constitution_wounds"));
-                creature->SetStatWound(ACTION, result->getUInt("action_wounds"));
-                creature->SetStatWound(QUICKNESS, result->getUInt("quickness_wounds"));
-                creature->SetStatWound(STAMINA, result->getUInt("stamina_wounds"));
-                creature->SetStatWound(MIND, result->getUInt("mind_wounds"));
-                creature->SetStatWound(FOCUS, result->getUInt("focus_wounds"));
-                creature->SetStatWound(WILLPOWER, result->getUInt("willpower_wounds"));
-
-                creature->SetStatBase(HEALTH, result->getUInt("health_wounds"));
-                creature->SetStatBase(STRENGTH, result->getUInt("strength_wounds"));
-                creature->SetStatBase(CONSTITUTION, result->getUInt("constitution_wounds"));
-                creature->SetStatBase(ACTION, result->getUInt("action_wounds"));
-                creature->SetStatBase(QUICKNESS, result->getUInt("quickness_wounds"));
-                creature->SetStatBase(STAMINA, result->getUInt("stamina_wounds"));
-                creature->SetStatBase(MIND, result->getUInt("mind_wounds"));
-                creature->SetStatBase(FOCUS, result->getUInt("focus_wounds"));
-                creature->SetStatBase(WILLPOWER, result->getUInt("willpower_wounds"));
-            }
-        }
-        
-		LoadBuffs_(creature, statement);
-        LoadSkills_(creature, statement);
-        LoadSkillMods_(creature, statement);
-        LoadSkillCommands_(creature, statement);
-
-		LoadContainedObjects(creature, statement);
-
-		//Clear us from the db persist update queue.
-		boost::lock_guard<boost::mutex> lock(persisted_objects_mutex_);
-		auto find_itr = persisted_objects_.find(creature);
-		if(find_itr != persisted_objects_.end())
-			persisted_objects_.erase(find_itr);
-    }
-    catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-    return creature;
-}
-
 shared_ptr<Object> CreatureFactory::CreateObject()
 {
 	return make_shared<Creature>();
-}
-
-void CreatureFactory::LoadBuffs_(
-	const shared_ptr<Creature>& creature,
-	const shared_ptr<sql::Statement>& statement)
-{
-	if(statement->getMoreResults())
-	{
-		unique_ptr<sql::ResultSet> result(statement->getResultSet());
-
-		while(result->next())
-		{
-			creature->AddBuff(result->getString("name"), result->getUInt("duration"));
-		}
-	}
-}
-
-void CreatureFactory::LoadSkills_(
-    const shared_ptr<Creature>& creature, 
-    const shared_ptr<sql::Statement>& statement)
-{
-    // Check for contained objects        
-    if (statement->getMoreResults())
-    {
-        unique_ptr<sql::ResultSet> result(statement->getResultSet());
-
-        string skill_name;
-
-        while (result->next())
-        {
-            skill_name = result->getString("name");
-
-            creature->AddSkill(skill_name);
-        }
-    }
-}
-
-void CreatureFactory::LoadSkillMods_(
-    const shared_ptr<Creature>& creature, 
-    const shared_ptr<sql::Statement>& statement)
-{
-    // Check for contained objects        
-    if (statement->getMoreResults())
-    {
-        unique_ptr<sql::ResultSet> result(statement->getResultSet());
-
-        string skill_mod_name;
-        uint32_t skill_mod_value;
-
-        while (result->next())
-        {
-            skill_mod_name = result->getString("name");
-            skill_mod_value = result->getUInt("value");
-
-            creature->AddSkillMod( 
-                SkillMod(skill_mod_name, skill_mod_value, 0)
-				);			
-        }
-    }
-}
-
-void CreatureFactory::LoadSkillCommands_(
-    const shared_ptr<Creature>& creature, 
-    const shared_ptr<sql::Statement>& statement)
-{
-     // Check for contained objects        
-    if (statement->getMoreResults())
-    {
-        unique_ptr<sql::ResultSet> result(statement->getResultSet());
-        while (result->next())
-        {
-           creature->AddSkillCommand(make_pair(result->getInt("id"), result->getString("name")));
-        }
-    }
 }
 
 void CreatureFactory::LoadSkills_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature)
@@ -489,10 +301,13 @@ void CreatureFactory::LoadSkills_(const std::shared_ptr<sql::Connection>& connec
     statement->setUInt64(1, creature->GetObjectId());
 
     auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
+    do
     {
-        creature->AddSkill(result->getString("name"));
-    }
+        while (result->next())
+        {
+            creature->AddSkill(result->getString("name"));
+        }
+    } while(statement->getMoreResults());
 }
 
 void CreatureFactory::LoadSkillMods_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature)
@@ -503,10 +318,13 @@ void CreatureFactory::LoadSkillMods_(const std::shared_ptr<sql::Connection>& con
     statement->setUInt64(1, creature->GetObjectId());
 
     auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
+    do
     {
-        creature->AddSkillMod(SkillMod(result->getString("name"), result->getUInt("value"), 0));	
-    }
+        while (result->next())
+        {
+            creature->AddSkillMod(SkillMod(result->getString("name"), result->getUInt("value"), 0));	
+        }
+    } while(statement->getMoreResults());
 }
 
 void CreatureFactory::LoadSkillCommands_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature)
@@ -516,11 +334,14 @@ void CreatureFactory::LoadSkillCommands_(const std::shared_ptr<sql::Connection>&
     
     statement->setUInt64(1, creature->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
-    {
-        creature->AddSkillCommand(std::make_pair(result->getInt("id"), result->getString("name")));
-    }
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
+    {  
+        while (result->next())
+        {
+            creature->AddSkillCommand(std::make_pair(result->getInt("id"), result->getString("name")));
+        }
+    } while(statement->getMoreResults());
 }
 
 void CreatureFactory::LoadBuffs_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<swganh::object::Creature>& creature)
@@ -530,9 +351,12 @@ void CreatureFactory::LoadBuffs_(const std::shared_ptr<sql::Connection>& connect
     
     statement->setUInt64(1, creature->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
     {
-        creature->AddBuff(result->getString("name"), result->getUInt("duration"));
-    }
+        while (result->next())
+        {
+            creature->AddBuff(result->getString("name"), result->getUInt("duration"));
+        }
+    } while(statement->getMoreResults());
 }

--- a/src/swganh_core/object/creature/creature_factory.h
+++ b/src/swganh_core/object/creature/creature_factory.h
@@ -26,6 +26,8 @@ namespace object {
 
         CreatureFactory(swganh::app::SwganhKernel* kernel);
 
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
+
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
@@ -36,8 +38,12 @@ namespace object {
         std::shared_ptr<swganh::object::Object> CreateObject();
         
     private:
-		void LoadBuffs_(const std::shared_ptr<swganh::object::Creature>& creature,
-			const std::shared_ptr<sql::Statement>& statement);
+        
+
+        void LoadSkills_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature);
+        void LoadSkillMods_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature);
+        void LoadSkillCommands_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Creature>& creature);
+		void LoadBuffs_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<swganh::object::Creature>& creature);
 
         void LoadSkills_(const std::shared_ptr<Creature>& creature, 
             const std::shared_ptr<sql::Statement>& statement);
@@ -47,6 +53,9 @@ namespace object {
 
         void LoadSkillCommands_(const std::shared_ptr<Creature>& creature, 
             const std::shared_ptr<sql::Statement>& statement);
+
+		void LoadBuffs_(const std::shared_ptr<swganh::object::Creature>& creature,
+			const std::shared_ptr<sql::Statement>& statement);
     };
 
 }}  // namespace swganh::object

--- a/src/swganh_core/object/factory_crate/factory_crate_factory.cc
+++ b/src/swganh_core/object/factory_crate/factory_crate_factory.cc
@@ -10,7 +10,11 @@ using namespace swganh::object;
 
 FactoryCrateFactory::FactoryCrateFactory(swganh::app::SwganhKernel* kernel)
 	: TangibleFactory(kernel)
+{}
+
+void FactoryCrateFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    TangibleFactory::LoadFromStorage(connection, object);
 }
 
 std::shared_ptr<swganh::object::Object> FactoryCrateFactory::CreateObject()

--- a/src/swganh_core/object/factory_crate/factory_crate_factory.h
+++ b/src/swganh_core/object/factory_crate/factory_crate_factory.h
@@ -19,6 +19,8 @@ namespace object {
 		typedef FactoryCrate ObjectType;
 
         FactoryCrateFactory(swganh::app::SwganhKernel* kernel);
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
 		virtual void PersistChangedObjects(){}
 

--- a/src/swganh_core/object/guild/guild_factory.cc
+++ b/src/swganh_core/object/guild/guild_factory.cc
@@ -19,8 +19,12 @@ using namespace std;
 using namespace swganh::object;
 
 GuildFactory::GuildFactory(swganh::app::SwganhKernel* kernel)
-			: ObjectFactory(kernel)
-{	
+    : ObjectFactory(kernel)
+{}
+
+void GuildFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
+{
+    ObjectFactory::LoadFromStorage(connection, object);
 }
 
 uint32_t GuildFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
@@ -30,11 +34,6 @@ uint32_t GuildFactory::PersistObject(const shared_ptr<Object>& object, bool pers
 
 void GuildFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {}
-
-shared_ptr<Object> GuildFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    return make_shared<Guild>();
-}
 
 shared_ptr<Object> GuildFactory::CreateObjectFromTemplate(const string& template_name, bool db_persisted, bool db_initialized)
 {

--- a/src/swganh_core/object/guild/guild_factory.h
+++ b/src/swganh_core/object/guild/guild_factory.h
@@ -14,12 +14,13 @@ namespace object {
     public:
 		GuildFactory(swganh::app::SwganhKernel* kernel);
 		typedef Guild ObjectType;
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
 		virtual void PersistChangedObjects(){}
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObjectFromTemplate(const std::string& template_name, bool db_persisted=true, bool db_initialized=true);
     };

--- a/src/swganh_core/object/harvester_installation/harvester_installation_factory.cc
+++ b/src/swganh_core/object/harvester_installation/harvester_installation_factory.cc
@@ -12,7 +12,11 @@ using namespace swganh::object;
 
 HarvesterInstallationFactory::HarvesterInstallationFactory(swganh::app::SwganhKernel* kernel)
 	: InstallationFactory(kernel)
+{}
+
+void HarvesterInstallationFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    InstallationFactory::LoadFromStorage(connection, object);
 }
 
 std::shared_ptr<Object> HarvesterInstallationFactory::CreateObject()

--- a/src/swganh_core/object/harvester_installation/harvester_installation_factory.h
+++ b/src/swganh_core/object/harvester_installation/harvester_installation_factory.h
@@ -14,6 +14,8 @@ namespace object {
 		typedef HarvesterInstallation ObjectType;
 		virtual void PersistChangedObjects(){}
         HarvesterInstallationFactory(swganh::app::SwganhKernel* kernel);
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
 		std::shared_ptr<swganh::object::Object> CreateObject();
     };

--- a/src/swganh_core/object/installation/installation_factory.cc
+++ b/src/swganh_core/object/installation/installation_factory.cc
@@ -3,8 +3,6 @@
 
 #include "installation_factory.h"
 
-#include "installation.h"
-
 #include <cppconn/exception.h>
 #include <cppconn/connection.h>
 #include <cppconn/resultset.h>
@@ -15,13 +13,57 @@
 
 #include "swganh/database/database_manager.h"
 
+#include "swganh_core/object/exception.h"
+
+#include "installation.h"
+
 using namespace std;
 using namespace swganh::object;
 
 InstallationFactory::InstallationFactory(swganh::app::SwganhKernel* kernel)
 	: TangibleFactory(kernel)
-{		
+{}
+
+void InstallationFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
+{    
+    TangibleFactory::LoadFromStorage(connection, object);
+
+    auto installation = std::dynamic_pointer_cast<Installation>(object);
+    if(!installation)
+    {
+        throw InvalidObject("Object requested for loading is not Intangible");
+    }
+
+    auto statement = std::shared_ptr<sql::PreparedStatement>
+        (connection->prepareStatement("CALL sp_GetInstallation(?);"));
+    
+    statement->setUInt64(1, installation->GetObjectId());
+
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
+    
+    do
+    {
+        while (result->next())
+        {
+            installation->SetSelectedResourceId(result->getUInt64("selected_resource_id"));
+
+            if (result->getInt("is_active") == 1)
+                installation->Activate();
+
+            installation->SetPowerReserve(static_cast<float>(result->getDouble("power_reserve")));
+            installation->SetPowerCost(static_cast<float>(result->getDouble("power_cost")));
+            installation->SetMaxExtractionRate(static_cast<float>(result->getDouble("max_extraction_rate")));
+            installation->SetCurrentExtractionRate(static_cast<float>(result->getDouble("current_extraction_rate")));
+            installation->SetCurrentHopperSize(static_cast<float>(result->getDouble("current_hopper_size")));
+
+            if (result->getInt("is_updating") == 1)
+                installation->StartUpdating();
+            
+            installation->SetConditionPercentage(result->getInt("condition_percentage"));
+        }
+    } while(statement->getMoreResults());
 }
+
 void InstallationFactory::RegisterEventHandlers()
 {
 	GetEventDispatcher()->Subscribe("Installation::Active", std::bind(&InstallationFactory::PersistHandler, this, std::placeholders::_1));
@@ -89,56 +131,6 @@ uint32_t InstallationFactory::PersistObject(const shared_ptr<Object>& object, bo
 void InstallationFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> InstallationFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-
-	auto installation = make_shared<Installation>();
-    installation->SetObjectId(object_id);
-    try {
-        auto conn = GetDatabaseManager()->getConnection("galaxy");
-        auto statement = shared_ptr<sql::Statement>(conn->createStatement());
-        unique_ptr<sql::ResultSet> result;
-        stringstream ss;
-        ss << "CALL sp_GetInstallation(" << object_id << ");" ;
-        statement->execute(ss.str());
-        CreateTangible(installation, statement);
-        
-        if (statement->getMoreResults())
-        {
-            result.reset(statement->getResultSet());
-            while (result->next())
-            {
-				installation->SetSelectedResourceId(result->getUInt64("selected_resource_id"));
-				int active = result->getInt("is_active");
-				if (active == 1)
-					installation->Activate();
-				installation->SetPowerReserve(static_cast<float>(result->getDouble("power_reserve")));
-				installation->SetPowerCost(static_cast<float>(result->getDouble("power_cost")));
-				installation->SetMaxExtractionRate(static_cast<float>(result->getDouble("max_extraction_rate")));
-				installation->SetCurrentExtractionRate(static_cast<float>(result->getDouble("current_extraction_rate")));
-				installation->SetCurrentHopperSize(static_cast<float>(result->getDouble("current_hopper_size")));
-				int updating = result->getInt("is_updating");
-				if (updating == 1)
-					installation->StartUpdating();
-
-				installation->SetConditionPercentage(result->getInt("condition_percentage"));
-			}
-		}
-
-		//Clear us from the db persist update queue.
-		boost::lock_guard<boost::mutex> lock(persisted_objects_mutex_);
-		auto find_itr = persisted_objects_.find(installation);
-		if(find_itr != persisted_objects_.end())
-			persisted_objects_.erase(find_itr);
-	}
-	catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-    return make_shared<Installation>();
 }
 
 shared_ptr<Object> InstallationFactory::CreateObject()

--- a/src/swganh_core/object/installation/installation_factory.cc
+++ b/src/swganh_core/object/installation/installation_factory.cc
@@ -97,8 +97,9 @@ void InstallationFactory::PersistChangedObjects()
 uint32_t InstallationFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
 	uint32_t counter = 1;
-	if (persist_inherited)
-		TangibleFactory::PersistObject(object, persist_inherited);
+	
+    TangibleFactory::PersistObject(object, persist_inherited);
+
 	try 
     {
         auto conn = GetDatabaseManager()->getConnection("galaxy");

--- a/src/swganh_core/object/installation/installation_factory.h
+++ b/src/swganh_core/object/installation/installation_factory.h
@@ -15,11 +15,12 @@ namespace object {
 		typedef Installation ObjectType;
 
         InstallationFactory(swganh::app::SwganhKernel* kernel);
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 		virtual void PersistChangedObjects();
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
-		std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
 

--- a/src/swganh_core/object/intangible/intangible_factory.cc
+++ b/src/swganh_core/object/intangible/intangible_factory.cc
@@ -59,9 +59,10 @@ uint32_t IntangibleFactory::PersistObject(const shared_ptr<Object>& object, bool
 {
 	// Persist Intangible
     uint32_t counter = 1;
-	if (persist_inherited)
-		ObjectFactory::PersistObject(object, persist_inherited);
-	try 
+	
+    ObjectFactory::PersistObject(object, persist_inherited);
+	
+    try 
     {
         auto conn = GetDatabaseManager()->getConnection("galaxy");
         auto statement = shared_ptr<sql::PreparedStatement>

--- a/src/swganh_core/object/intangible/intangible_factory.h
+++ b/src/swganh_core/object/intangible/intangible_factory.h
@@ -19,6 +19,9 @@ namespace object {
     {
     public:
         IntangibleFactory(swganh::app::SwganhKernel* kernel);
+
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
+
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);

--- a/src/swganh_core/object/intangible/intangible_factory.h
+++ b/src/swganh_core/object/intangible/intangible_factory.h
@@ -26,7 +26,6 @@ namespace object {
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
 		virtual void PersistChangedObjects(){}
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
 

--- a/src/swganh_core/object/manufacture_schematic/manufacture_schematic_factory.cc
+++ b/src/swganh_core/object/manufacture_schematic/manufacture_schematic_factory.cc
@@ -14,6 +14,11 @@ ManufactureSchematicFactory::ManufactureSchematicFactory(swganh::app::SwganhKern
 {
 }
 
+void ManufactureSchematicFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
+{
+    IntangibleFactory::LoadFromStorage(connection, object);
+}
+
 uint32_t ManufactureSchematicFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
 	return 0;
@@ -22,11 +27,6 @@ uint32_t ManufactureSchematicFactory::PersistObject(const shared_ptr<Object>& ob
 void ManufactureSchematicFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> ManufactureSchematicFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    return make_shared<ManufactureSchematic>();
 }
 
 shared_ptr<Object> ManufactureSchematicFactory::CreateObject()

--- a/src/swganh_core/object/manufacture_schematic/manufacture_schematic_factory.h
+++ b/src/swganh_core/object/manufacture_schematic/manufacture_schematic_factory.h
@@ -15,12 +15,12 @@ namespace object {
 		typedef ManufactureSchematic ObjectType;
 
 		ManufactureSchematicFactory(swganh::app::SwganhKernel* kernel);
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 		virtual void PersistChangedObjects(){}
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
-
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
     };

--- a/src/swganh_core/object/mission/mission_factory.cc
+++ b/src/swganh_core/object/mission/mission_factory.cc
@@ -11,7 +11,11 @@ using namespace swganh::object;
 
 MissionFactory::MissionFactory(swganh::app::SwganhKernel* kernel)
 	: IntangibleFactory(kernel)
+{}
+
+void MissionFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    IntangibleFactory::LoadFromStorage(connection, object);
 }
 
 uint32_t MissionFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
@@ -24,11 +28,6 @@ uint32_t MissionFactory::PersistObject(const shared_ptr<Object>& object, bool pe
 void MissionFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> MissionFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    return make_shared<Mission>();
 }
 
 shared_ptr<Object> MissionFactory::CreateObject()

--- a/src/swganh_core/object/mission/mission_factory.h
+++ b/src/swganh_core/object/mission/mission_factory.h
@@ -15,12 +15,14 @@ namespace object {
 		typedef Mission ObjectType;
 
 		MissionFactory(swganh::app::SwganhKernel* kernel);
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
-		virtual void PersistChangedObjects(){}
-        void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
+		
+        virtual void PersistChangedObjects(){}
 
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
+        void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
     };

--- a/src/swganh_core/object/object.cc
+++ b/src/swganh_core/object/object.cc
@@ -811,7 +811,7 @@ void Object::CreateBaselines( std::shared_ptr<swganh::observer::ObserverInterfac
 
 void Object::SendCreateByCrc(std::shared_ptr<swganh::observer::ObserverInterface> observer) 
 {
-	//DLOG(info) << "SEND " << GetObjectId() << " TO " << observer->GetId();
+	DLOG(info) << "SEND [" << GetObjectId() << "] (" << GetTemplate() <<") TO " << observer->GetId();
 
 	swganh::messages::SceneCreateObjectByCrc scene_object;
     scene_object.object_id = GetObjectId();
@@ -821,7 +821,7 @@ void Object::SendCreateByCrc(std::shared_ptr<swganh::observer::ObserverInterface
     scene_object.byte_flag = 0;
     observer->Notify(&scene_object);
 
-	SendUpdateContainmentMessage(observer, false);
+	SendUpdateContainmentMessage(observer);
 }
 
 void Object::SendUpdateContainmentMessage(std::shared_ptr<swganh::observer::ObserverInterface> observer, bool send_on_no_parent)
@@ -1059,7 +1059,7 @@ std::wstring Object::GetAttributeRecursiveAsString(const std::string& name)
 				ss << boost::get<int64_t>(val);
 				break;
 			case 2:
-				ss << boost::get<wstring>(val);
+				return boost::get<wstring>(val);
 				break;
 			case 3:
 				ss << L"";
@@ -1115,8 +1115,7 @@ AttributeVariant Object::GetAttributeRecursive(const std::string& name)
 				int_val = boost::get<int64_t>(val);
 				return AddAttributeRecursive<int64_t>(int_val, name);			
 			case 2:
-				attr_val = boost::get<wstring>(val);
-				return AddAttributeRecursive<wstring>(attr_val, name);			
+				return boost::get<wstring>(val);		
 			case 3:
 				return boost::blank();				
 		}	

--- a/src/swganh_core/object/object.cc
+++ b/src/swganh_core/object/object.cc
@@ -811,7 +811,7 @@ void Object::CreateBaselines( std::shared_ptr<swganh::observer::ObserverInterfac
 
 void Object::SendCreateByCrc(std::shared_ptr<swganh::observer::ObserverInterface> observer) 
 {
-	DLOG(info) << "SEND [" << GetObjectId() << "] (" << GetTemplate() <<") TO " << observer->GetId();
+	//DLOG(info) << "SEND [" << GetObjectId() << "] (" << GetTemplate() <<") TO " << observer->GetId();
 
 	swganh::messages::SceneCreateObjectByCrc scene_object;
     scene_object.object_id = GetObjectId();

--- a/src/swganh_core/object/object_factory.cc
+++ b/src/swganh_core/object/object_factory.cc
@@ -203,10 +203,9 @@ uint32_t ObjectFactory::PersistObject(const shared_ptr<Object>& object, bool per
 
 void ObjectFactory::LoadAttributes(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
-    auto statement = connection->prepareStatement("CALL sp_GetAttributes(?,?);");
+    auto statement = connection->prepareStatement("CALL sp_GetAttributes(?);");
 
-    statement->setString(1, object->GetTemplate());
-    statement->setUInt64(2, object->GetObjectId());
+    statement->setUInt64(1, object->GetObjectId());
 
     auto result = unique_ptr<sql::ResultSet>(statement->executeQuery());         
     do
@@ -251,6 +250,7 @@ void ObjectFactory::PersistAttributes(std::shared_ptr<Object> object)
 			statement->setString(2, name);
 			std::wstring attr = object->GetAttributeRecursiveAsString(name);
 			statement->setString(3, std::string(attr.begin(), attr.end()));
+                        
 			statement->executeUpdate();    
 		}		
 	}
@@ -270,7 +270,7 @@ uint32_t ObjectFactory::LookupType(uint64_t object_id)
     uint32_t type = 0;
     try {
 		auto conn = GetDatabaseManager()->getConnection("galaxy");
-        auto statement = conn->prepareStatement("CALL sp_GetType(?);");
+        auto statement = conn->prepareStatement("CALL sp_GetObjectType(?);");
         statement->setUInt64(1, object_id);
         auto result = unique_ptr<sql::ResultSet>(statement->executeQuery());        
         while (result->next())

--- a/src/swganh_core/object/object_factory.cc
+++ b/src/swganh_core/object/object_factory.cc
@@ -55,58 +55,61 @@ std::shared_ptr<Object> ObjectFactory::LoadDataFromStorage(const std::shared_ptr
 
 void ObjectFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
-    auto statement = shared_ptr<sql::PreparedStatement>
-        (connection->prepareStatement("CALL sp_GetObject(?);"));
+    std::unique_ptr<sql::PreparedStatement> statement(connection->prepareStatement("CALL sp_GetObject(?);"));
 
     statement->setUInt64(1, object->GetObjectId());
     
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());        
-    while (result->next())
+    std::unique_ptr<sql::ResultSet> result(statement->executeQuery());        
+    
+    do
     {
-        object->SetEventDispatcher(GetEventDispatcher());
+        while (result->next())
+        {
+            object->SetEventDispatcher(GetEventDispatcher());
 
-        object->SetSceneId(result->getUInt("scene_id"));
-        object->SetPosition(glm::vec3(result->getDouble("x_position"),result->getDouble("y_position"), result->getDouble("z_position")));
-        object->UpdateWorldCollisionBox();
-        object->UpdateAABB();
-    
-        object->SetOrientation(glm::quat(
-            static_cast<float>(result->getDouble("w_orientation")),
-        	static_cast<float>(result->getDouble("x_orientation")),
-            static_cast<float>(result->getDouble("y_orientation")),
-            static_cast<float>(result->getDouble("z_orientation"))));
+            object->SetSceneId(result->getUInt("scene_id"));
+            object->SetPosition(glm::vec3(result->getDouble("x_position"),result->getDouble("y_position"), result->getDouble("z_position")));
+            object->UpdateWorldCollisionBox();
+            object->UpdateAABB();
         
-        object->SetComplexity(static_cast<float>(result->getDouble("complexity")));
-        object->SetStfName(result->getString("stf_name_file"),
-                           result->getString("stf_name_string"));
-        string custom_string = result->getString("custom_name");
-        object->SetCustomName(wstring(begin(custom_string), end(custom_string)));
-        object->SetVolume(result->getUInt("volume"));
-        object->SetTemplate(result->getString("iff_template"));
-        object->SetArrangementId(result->getInt("arrangement_id"));
-        object->SetAttributeTemplateId(result->getInt("attribute_template_id"));
-    
-        auto permissions_objects_ = object_manager_->GetPermissionsMap();
-        auto permissions_itr = permissions_objects_.find(result->getInt("permission_type"));
-        if(permissions_itr != permissions_objects_.end())
-        {
-        	object->SetPermissions(permissions_itr->second);
+            object->SetOrientation(glm::quat(
+                static_cast<float>(result->getDouble("w_orientation")),
+            	static_cast<float>(result->getDouble("x_orientation")),
+                static_cast<float>(result->getDouble("y_orientation")),
+                static_cast<float>(result->getDouble("z_orientation"))));
+            
+            object->SetComplexity(static_cast<float>(result->getDouble("complexity")));
+            object->SetStfName(result->getString("stf_name_file"),
+                               result->getString("stf_name_string"));
+            string custom_string = result->getString("custom_name");
+            object->SetCustomName(wstring(begin(custom_string), end(custom_string)));
+            object->SetVolume(result->getUInt("volume"));
+            object->SetTemplate(result->getString("iff_template"));
+            object->SetArrangementId(result->getInt("arrangement_id"));
+            object->SetAttributeTemplateId(result->getInt("attribute_template_id"));
+        
+            auto permissions_objects_ = object_manager_->GetPermissionsMap();
+            auto permissions_itr = permissions_objects_.find(result->getInt("permission_type"));
+            if(permissions_itr != permissions_objects_.end())
+            {
+            	object->SetPermissions(permissions_itr->second);
+            }
+            else
+            {
+            	DLOG(error) << "FAILED TO FIND PERMISSION TYPE " << result->getInt("perission_type");
+            	object->SetPermissions(permissions_objects_.find(DEFAULT_PERMISSION)->second);
+            }
+        
+            auto parent = object_manager_->GetObjectById(result->getUInt64("parent_id"));
+            if(parent != nullptr)
+            {
+            	parent->AddObject(nullptr, object);
+            }
         }
-        else
-        {
-        	DLOG(error) << "FAILED TO FIND PERMISSION TYPE " << result->getInt("perission_type");
-        	object->SetPermissions(permissions_objects_.find(DEFAULT_PERMISSION)->second);
-        }
-    
-        auto parent = object_manager_->GetObjectById(result->getUInt64("parent_id"));
-        if(parent != nullptr)
-        {
-        	parent->AddObject(nullptr, object);
-        }
+    } while(statement->getMoreResults());
 
-		LoadAttributes(connection, object);
-		GetClientData(object);
-    }
+	LoadAttributes(connection, object);
+	GetClientData(object);
 }
 
 void ObjectFactory::RegisterEventHandlers()
@@ -136,6 +139,7 @@ void ObjectFactory::PersistChangedObjects()
 			PersistObject(object);
 	}
 }
+
 void ObjectFactory::PersistHandler(const shared_ptr<swganh::EventInterface>& incoming_event)
 {
 	auto object = static_pointer_cast<ObjectEvent>(incoming_event)->Get();
@@ -145,6 +149,7 @@ void ObjectFactory::PersistHandler(const shared_ptr<swganh::EventInterface>& inc
 		persisted_objects_.insert(object);
 	}
 }
+
 uint32_t ObjectFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
 	uint32_t counter = 1;
@@ -196,87 +201,6 @@ uint32_t ObjectFactory::PersistObject(const shared_ptr<Object>& object, bool per
 	return counter;
 }
 
-void ObjectFactory::CreateBaseObjectFromStorage(const shared_ptr<Object>& object, const shared_ptr<sql::ResultSet>& result)
-{
-    try {
-        result->next();
-        // Set Event Dispatcher
-        object->SetEventDispatcher(GetEventDispatcher());
-        object->SetSceneId(result->getUInt("scene_id"));
-        object->SetPosition(glm::vec3(result->getDouble("x_position"),result->getDouble("y_position"), result->getDouble("z_position")));
-		object->UpdateWorldCollisionBox();
-		object->UpdateAABB();
-
-        object->SetOrientation(glm::quat(
-            static_cast<float>(result->getDouble("w_orientation")),
-			static_cast<float>(result->getDouble("x_orientation")),
-            static_cast<float>(result->getDouble("y_orientation")),
-            static_cast<float>(result->getDouble("z_orientation"))));
-
-        object->SetComplexity(static_cast<float>(result->getDouble("complexity")));
-        object->SetStfName(result->getString("stf_name_file"),
-                           result->getString("stf_name_string"));
-        string custom_string = result->getString("custom_name");
-        object->SetCustomName(wstring(begin(custom_string), end(custom_string)));
-        object->SetVolume(result->getUInt("volume"));
-        object->SetTemplate(result->getString("iff_template"));
-		object->SetArrangementId(result->getInt("arrangement_id"));
-
-		auto permissions_objects_ = object_manager_->GetPermissionsMap();
-		auto permissions_itr = permissions_objects_.find(result->getInt("permission_type"));
-		if(permissions_itr != permissions_objects_.end())
-		{
-			object->SetPermissions(permissions_itr->second);
-		}
-		else
-		{
-			DLOG(error) << "FAILED TO FIND PERMISSION TYPE " << result->getInt("perission_type");
-			object->SetPermissions(permissions_objects_.find(DEFAULT_PERMISSION)->second);
-		}
-		object_manager_->LoadSlotsForObject(object);
-		object_manager_->LoadCollisionInfoForObject(object);
-
-		auto parent = object_manager_->GetObjectById(result->getUInt64("parent_id"));
-		if(parent != nullptr)
-		{
-			parent->AddObject(nullptr, object);
-		}
-		// Attribute Template ID
-		int attribute_template_id = result->getInt("attribute_template_id");
-		object->SetAttributeTemplateId(attribute_template_id);
-
-		LoadAttributes(object);
-
-		GetClientData(object);
-
-		//Clear us from the db persist update queue.
-		boost::lock_guard<boost::mutex> lock(persisted_objects_mutex_);
-		auto find_itr = persisted_objects_.find(object);
-		if(find_itr != persisted_objects_.end())
-			persisted_objects_.erase(find_itr);
-
-    }
-    catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
-
-void ObjectFactory::LoadAttributes(std::shared_ptr<Object> object)
-{
-	 try {
-        auto conn = GetDatabaseManager()->getConnection("galaxy");
-
-        LoadAttributes(conn, object);
-    }
-    catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();        
-    }
-}
-
 void ObjectFactory::LoadAttributes(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
     auto statement = connection->prepareStatement("CALL sp_GetAttributes(?,?);");
@@ -284,31 +208,34 @@ void ObjectFactory::LoadAttributes(const std::shared_ptr<sql::Connection>& conne
     statement->setString(1, object->GetTemplate());
     statement->setUInt64(2, object->GetObjectId());
 
-    auto result = unique_ptr<sql::ResultSet>(statement->executeQuery());        
-    while (result->next())
+    auto result = unique_ptr<sql::ResultSet>(statement->executeQuery());         
+    do
     {
-        string attr_name = result->getString("name");
-        string unparsed_value = result->getString("attribute_value");
-        try {				
-            if (std::string::npos != unparsed_value.find("."))
-            {
-                object->SetAttribute(attr_name, boost::lexical_cast<float>(unparsed_value));
+        while (result->next())
+        {
+            string attr_name = result->getString("name");
+            string unparsed_value = result->getString("attribute_value");
+            try {				
+                if (std::string::npos != unparsed_value.find("."))
+                {
+                    object->SetAttribute(attr_name, boost::lexical_cast<float>(unparsed_value));
+                }
+                else if (unparsed_value.find_first_of("0123456789") == 0)
+                {
+                    object->SetAttribute(attr_name, boost::lexical_cast<int64_t>(unparsed_value));
+                }
+                else
+                {
+                    object->SetAttribute(attr_name, std::wstring(unparsed_value.begin(), unparsed_value.end()));
+                }
             }
-            else if (unparsed_value.find_first_of("0123456789") == 0)
+            catch (std::exception& e)
             {
-                object->SetAttribute(attr_name, boost::lexical_cast<int64_t>(unparsed_value));
-            }
-            else
-            {
+                LOG(error) << "Error parsing attribute " << attr_name <<" for object_id:" << object->GetObjectId() << " error message:" << e.what();
                 object->SetAttribute(attr_name, std::wstring(unparsed_value.begin(), unparsed_value.end()));
             }
         }
-        catch (std::exception& e)
-        {
-            LOG(error) << "Error parsing attribute " << attr_name <<" for object_id:" << object->GetObjectId() << " error message:" << e.what();
-            object->SetAttribute(attr_name, std::wstring(unparsed_value.begin(), unparsed_value.end()));
-        }
-    }
+    } while(statement->getMoreResults());
 }
 
 void ObjectFactory::PersistAttributes(std::shared_ptr<Object> object)

--- a/src/swganh_core/object/object_factory.h
+++ b/src/swganh_core/object/object_factory.h
@@ -46,6 +46,12 @@ namespace object {
 
         void SetObjectManager(ObjectManager* object_manager) { object_manager_ = object_manager; }
 
+        virtual std::future<std::shared_ptr<Object>> LoadFromStorage(uint64_t object_id);
+
+        virtual std::shared_ptr<Object> LoadDataFromStorage(const std::shared_ptr<sql::Connection>& connection, uint64_t object_id);
+
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
+
         /**
          * Loads in base values from a result set
          *
@@ -59,15 +65,18 @@ namespace object {
         virtual std::shared_ptr<Object> CreateObjectFromStorage(uint64_t object_id){ return nullptr; }
 		virtual std::shared_ptr<Object> CreateObject() { return nullptr; }
         uint32_t LookupType(uint64_t object_id);
+        void LoadAttributes(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 		void LoadAttributes(std::shared_ptr<Object> object);
 		void PersistAttributes(std::shared_ptr<Object> object);
 
 		virtual void PersistChangedObjects();
 		void PersistHandler(const std::shared_ptr<swganh::EventInterface>& incoming_event);
         virtual void RegisterEventHandlers();
-        void SetTreArchive(swganh::tre::TreArchive* tre_archive);
+
 		// Fiils in missing data for the object from the client file...
 		void GetClientData(const std::shared_ptr<Object>& object);
+        
+        void LoadContainedObjects(const std::shared_ptr<Object>& object);
 
 		swganh::database::DatabaseManager* GetDatabaseManager() { return kernel_->GetDatabaseManager(); }
 		swganh::EventDispatcher* GetEventDispatcher() { return kernel_->GetEventDispatcher(); }
@@ -76,9 +85,7 @@ namespace object {
             const std::shared_ptr<sql::Statement>& statement);
         
         void LoadContainedObjects(const std::shared_ptr<Object>& object, const std::unique_ptr<sql::ResultSet>& result);
-
-        void LoadContainedObjects(const std::shared_ptr<Object>& object);
-        
+                
         ObjectManager* object_manager_;
 		boost::mutex persisted_objects_mutex_;
 		swganh::app::SwganhKernel* kernel_;         

--- a/src/swganh_core/object/object_factory.h
+++ b/src/swganh_core/object/object_factory.h
@@ -9,6 +9,7 @@
 #include "swganh/app/swganh_kernel.h"
 
 #include <set>
+#include <boost/optional.hpp>
 #include <boost/thread/mutex.hpp>
 
 namespace swganh {
@@ -77,7 +78,10 @@ namespace object {
             const std::shared_ptr<sql::Statement>& statement);
         
         void LoadContainedObjects(const std::shared_ptr<Object>& object, const std::unique_ptr<sql::ResultSet>& result);
-                
+
+        boost::optional<float> IsFloat(const std::string& value) const;
+        boost::optional<int64_t> IsInteger(const std::string& value) const;
+
         ObjectManager* object_manager_;
 		boost::mutex persisted_objects_mutex_;
 		swganh::app::SwganhKernel* kernel_;         

--- a/src/swganh_core/object/object_factory.h
+++ b/src/swganh_core/object/object_factory.h
@@ -52,21 +52,13 @@ namespace object {
 
         virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
-        /**
-         * Loads in base values from a result set
-         *
-         * @param the object which to load values into
-         * @param the result set from which to load the values from
-         */
-        void CreateBaseObjectFromStorage(const std::shared_ptr<Object>& object, const std::shared_ptr<sql::ResultSet>& result);
         virtual uint32_t PersistObject(const std::shared_ptr<Object>& object, bool persist_inherited = false);
         
         virtual void DeleteObjectFromStorage(const std::shared_ptr<Object>& object);
-        virtual std::shared_ptr<Object> CreateObjectFromStorage(uint64_t object_id){ return nullptr; }
+
 		virtual std::shared_ptr<Object> CreateObject() { return nullptr; }
         uint32_t LookupType(uint64_t object_id);
         void LoadAttributes(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
-		void LoadAttributes(std::shared_ptr<Object> object);
 		void PersistAttributes(std::shared_ptr<Object> object);
 
 		virtual void PersistChangedObjects();

--- a/src/swganh_core/object/object_factory_interface.h
+++ b/src/swganh_core/object/object_factory_interface.h
@@ -3,8 +3,11 @@
 #pragma once
 
 #include <cstdint>
+#include <future>
 #include <memory>
 #include <string>
+
+#include <cppconn/connection.h>
 
 namespace swganh {
 namespace object {
@@ -38,6 +41,18 @@ namespace object {
          * @throws InvalidObject when no object exists for the specified id.
          */
         virtual std::shared_ptr<Object> CreateObjectFromStorage(uint64_t object_id) = 0;
+        
+        /**
+         * Creates an instance of a stored object with the specified id.
+         *
+         * Intended to be passed to DatabaseManager::ExecuteAsync
+         *
+         * @return a future to the created object instance.
+         * @throws InvalidObject when no object exists for the specified id.
+         */
+        virtual std::future<std::shared_ptr<Object>> LoadFromStorage(uint64_t object_id) = 0;
+        
+        virtual void LoadContainedObjects(const std::shared_ptr<Object>& object) = 0;
                 
         /**
          * Creates an instance of an object from the specified template.

--- a/src/swganh_core/object/object_factory_interface.h
+++ b/src/swganh_core/object/object_factory_interface.h
@@ -37,14 +37,6 @@ namespace object {
         /**
          * Creates an instance of a stored object with the specified id.
          *
-         * @return the created object instance.
-         * @throws InvalidObject when no object exists for the specified id.
-         */
-        virtual std::shared_ptr<Object> CreateObjectFromStorage(uint64_t object_id) = 0;
-        
-        /**
-         * Creates an instance of a stored object with the specified id.
-         *
          * Intended to be passed to DatabaseManager::ExecuteAsync
          *
          * @return a future to the created object instance.

--- a/src/swganh_core/object/object_manager.cc
+++ b/src/swganh_core/object/object_manager.cc
@@ -74,7 +74,7 @@ ObjectManager::ObjectManager(swganh::app::SwganhKernel* kernel)
 	//Load slot definitions
 	slot_definition_ = kernel->GetResourceManager()->GetResourceByName<SlotDefinitionVisitor>("abstract/slot/slot_definition/slot_definitions.iff");
 
-	persist_timer_ = std::make_shared<boost::asio::deadline_timer>(kernel_->GetCpuThreadPool(), boost::posix_time::minutes(5));
+	persist_timer_ = std::make_shared<boost::asio::deadline_timer>(kernel_->GetCpuThreadPool(), boost::posix_time::seconds(30));
 	persist_timer_->async_wait(boost::bind(&ObjectManager::PersistObjectsByTimer, this, boost::asio::placeholders::error));
 
 	// Load the highest object_id from the db
@@ -139,7 +139,7 @@ void ObjectManager::PersistObjectsByTimer(const boost::system::error_code& e)
 		{
 			factory.second->PersistChangedObjects();
 		}
-		persist_timer_->expires_from_now(boost::posix_time::minutes(5));
+		persist_timer_->expires_from_now(boost::posix_time::seconds(30));
 		persist_timer_->async_wait(boost::bind(&ObjectManager::PersistObjectsByTimer, this, boost::asio::placeholders::error));
 	}
 	else

--- a/src/swganh_core/object/player/player_factory.cc
+++ b/src/swganh_core/object/player/player_factory.cc
@@ -136,8 +136,9 @@ void PlayerFactory::PersistChangedObjects()
 uint32_t PlayerFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
 	uint32_t counter = 1;
-	if (persist_inherited)
-		IntangibleFactory::PersistObject(object, persist_inherited);
+	
+    IntangibleFactory::PersistObject(object, persist_inherited);
+
     try 
     {
         auto conn = GetDatabaseManager()->getConnection("galaxy");

--- a/src/swganh_core/object/player/player_factory.cc
+++ b/src/swganh_core/object/player/player_factory.cc
@@ -31,7 +31,6 @@ PlayerFactory::PlayerFactory(swganh::app::SwganhKernel* kernel)
     : IntangibleFactory(kernel)
 {}
 
-
 void PlayerFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
     IntangibleFactory::LoadFromStorage(connection, object);
@@ -42,44 +41,48 @@ void PlayerFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& conn
         throw InvalidObject("Object requested for loading is not Intangible");
     }
 
-    auto statement = std::shared_ptr<sql::PreparedStatement>
+    auto statement = std::unique_ptr<sql::PreparedStatement>
         (connection->prepareStatement("CALL sp_GetPlayer(?);"));
     
     statement->setUInt64(1, player->GetObjectId());
   
-    auto result = std::unique_ptr<sql::ResultSet>(statement->getResultSet());
-    while (result->next())
-    {
-        // Player specific start
-        player->SetProfessionTag(result->getString("profession_tag"));
-        player->SetBornDate(result->getUInt("born_date"));
-        player->SetTotalPlayTime(result->getUInt("total_playtime"));
-        player->SetAdminTag(result->getUInt("csr_tag"));
-        player->SetCurrentForcePower(result->getUInt("current_force"));
-        player->SetMaxForcePower(result->getUInt("max_force"));
-        player->SetExperimentationFlag(result->getUInt("experimentation_enabled"));
-        player->SetCraftingStage(result->getUInt("crafting_stage"));
-        player->SetNearestCraftingStation(result->getUInt64("nearest_crafting_station"));
-        player->AddExperimentationPoints(result->getUInt("experimentation_points"));
-        player->ResetAccomplishmentCounter(result->getUInt("accomplishment_counter"));
-        player->SetLanguage(result->getUInt("current_language"));
-        player->ResetCurrentStomach(result->getUInt("current_stomach"));
-        player->ResetMaxStomach(result->getUInt("max_stomach"));
-        player->ResetCurrentDrink(result->getUInt("current_drink"));
-        player->ResetMaxDrink(result->getUInt("max_drink"));
-        player->SetJediState(result->getUInt("jedi_state"));
-    }
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+
+    do
+    { 
+        while (result->next())
+        {
+            // Player specific start
+            player->SetProfessionTag(result->getString("profession_tag"));
+            player->SetBornDate(result->getUInt("born_date"));
+            player->SetTotalPlayTime(result->getUInt("total_playtime"));
+            player->SetAdminTag(result->getUInt("csr_tag"));
+            player->SetCurrentForcePower(result->getUInt("current_force"));
+            player->SetMaxForcePower(result->getUInt("max_force"));
+            player->SetExperimentationFlag(result->getUInt("experimentation_enabled"));
+            player->SetCraftingStage(result->getUInt("crafting_stage"));
+            player->SetNearestCraftingStation(result->getUInt64("nearest_crafting_station"));
+            player->AddExperimentationPoints(result->getUInt("experimentation_points"));
+            player->ResetAccomplishmentCounter(result->getUInt("accomplishment_counter"));
+            player->SetLanguage(result->getUInt("current_language"));
+            player->ResetCurrentStomach(result->getUInt("current_stomach"));
+            player->ResetMaxStomach(result->getUInt("max_stomach"));
+            player->ResetCurrentDrink(result->getUInt("current_drink"));
+            player->ResetMaxDrink(result->getUInt("max_drink"));
+            player->SetJediState(result->getUInt("jedi_state"));
+        }
+    } while(statement->getMoreResults());
     
-    //LoadStatusFlags_(connection, player);
-    //LoadProfileFlags_(connection, player);
-    //LoadBadges_(connection, player);
-    //LoadDraftSchematics_(connection, player);
-    //LoadFriends_(connection, player);
-    //LoadForceSensitiveQuests_(connection, player);
-    //LoadIgnoredList_(connection, player);
-    //LoadQuestJournal_(connection, player);
-    //LoadWaypoints_(connection, player);
-    //LoadXP_(connection, player);
+    LoadStatusFlags_(connection, player);
+    LoadProfileFlags_(connection, player);
+    LoadBadges_(connection, player);
+    LoadDraftSchematics_(connection, player);
+    LoadFriends_(connection, player);
+    LoadForceSensitiveQuests_(connection, player);
+    LoadIgnoredList_(connection, player);
+    LoadQuestJournal_(connection, player);
+    LoadWaypoints_(connection, player);
+    LoadXP_(connection, player);
 }
 
 void PlayerFactory::RegisterEventHandlers()
@@ -115,6 +118,7 @@ void PlayerFactory::RegisterEventHandlers()
 	GetEventDispatcher()->Subscribe("Player::JediState", std::bind(&PlayerFactory::PersistHandler, this, std::placeholders::_1));
 	GetEventDispatcher()->Subscribe("Player::Badges", std::bind(&PlayerFactory::PersistHandler, this, std::placeholders::_1));
 }
+
 void PlayerFactory::PersistChangedObjects()
 {
 	std::set<shared_ptr<Object>> persisted;
@@ -128,6 +132,7 @@ void PlayerFactory::PersistChangedObjects()
 			PersistObject(object);
 	}
 }
+
 uint32_t PlayerFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
 	uint32_t counter = 1;
@@ -180,159 +185,12 @@ void PlayerFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
     ObjectFactory::DeleteObjectFromStorage(object);
 }
 
-shared_ptr<Object> PlayerFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    auto player = make_shared<Player>();
-    player->SetObjectId(object_id);
-    try {
-
-        auto conn = GetDatabaseManager()->getConnection("galaxy");
-        auto statement = shared_ptr<sql::Statement>(conn->createStatement());
-        
-        stringstream ss;
-        ss << "CALL sp_GetPlayer(" << object_id << ");";
-
-        auto result = shared_ptr<sql::ResultSet>(statement->executeQuery(ss.str()));
-        CreateBaseObjectFromStorage(player, result);
-        if (statement->getMoreResults())
-        {
-            result.reset(statement->getResultSet());
-            while (result->next())
-            {
-                // Player specific start
-                player->SetProfessionTag(result->getString("profession_tag"));
-                player->SetBornDate(result->getUInt("born_date"));
-                player->SetTotalPlayTime(result->getUInt("total_playtime"));
-                player->SetAdminTag(result->getUInt("csr_tag"));
-                player->SetCurrentForcePower(result->getUInt("current_force"));
-                player->SetMaxForcePower(result->getUInt("max_force"));
-                player->SetExperimentationFlag(result->getUInt("experimentation_enabled"));
-                player->SetCraftingStage(result->getUInt("crafting_stage"));
-                player->SetNearestCraftingStation(result->getUInt64("nearest_crafting_station"));
-                player->AddExperimentationPoints(result->getUInt("experimentation_points"));
-                player->ResetAccomplishmentCounter(result->getUInt("accomplishment_counter"));
-                player->SetLanguage(result->getUInt("current_language"));
-                player->ResetCurrentStomach(result->getUInt("current_stomach"));
-                player->ResetMaxStomach(result->getUInt("max_stomach"));
-                player->ResetCurrentDrink(result->getUInt("current_drink"));
-                player->ResetMaxDrink(result->getUInt("max_drink"));
-                player->SetJediState(result->getUInt("jedi_state"));
-            }
-
-            LoadStatusFlags_(player, statement);
-            LoadProfileFlags_(player, statement);
-			LoadBadges_(player, statement);
-            LoadDraftSchematics_(player, statement);
-            LoadFriends_(player, statement);
-            LoadForceSensitiveQuests_(player, statement);
-            LoadIgnoredList_(player, statement);
-            LoadQuestJournal_(player, statement);
-            LoadWaypoints_(player, statement);
-            LoadXP_(player, statement);
-        }
-
-		//Clear us from the db persist update queue.
-		boost::lock_guard<boost::mutex> lock(persisted_objects_mutex_);
-		auto find_itr = persisted_objects_.find(player);
-		if(find_itr != persisted_objects_.end())
-			persisted_objects_.erase(find_itr);
-    }
-    catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-    return player;
-}
-
 shared_ptr<Object> PlayerFactory::CreateObject()
 {
 	//@TODO: Create me with help from db
 	return make_shared<Player>();
 }
 
-void PlayerFactory::LoadStatusFlags_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{    
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = unique_ptr<sql::ResultSet>(statement->getResultSet());
-            while (result->next())
-            {
-               player->AddStatusFlag(static_cast<StatusFlags>(result->getUInt("flag")));
-            }
-        }
-    }
-    catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
-
-void PlayerFactory::LoadProfileFlags_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = unique_ptr<sql::ResultSet>(statement->getResultSet());
-            while (result->next())
-            {
-               player->AddProfileFlag(static_cast<ProfileFlags>(result->getUInt("flag")));
-            }
-        }
-    }
-        catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
-
-void PlayerFactory::LoadBadges_(shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-	try
-	{
-		if(statement->getMoreResults())
-		{
-			auto result = unique_ptr<sql::ResultSet>(statement->getResultSet());
-			while(result->next())
-			{
-				auto badge_id = result->getUInt("badge");
-				player->AddBadge(badge_id);
-			}
-		}
-	}
-	catch(sql::SQLException &e)
-	{
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-	}
-}
-
-// Helpers
-void PlayerFactory::LoadXP_(shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = unique_ptr<sql::ResultSet>(statement->getResultSet());
-            while (result->next())
-            {
-                player->AddExperience(XpData(result->getString("name"), result->getUInt("value")));
-
-            }
-        }
-    }
-        catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
 void PlayerFactory::PersistXP_(const shared_ptr<Player>& player)
 {
     try 
@@ -346,46 +204,6 @@ void PlayerFactory::PersistXP_(const shared_ptr<Player>& player)
             statement->setUInt(2,xpData.second.value);
             auto result = unique_ptr<sql::ResultSet>(statement->executeQuery());
         };
-    }
-        catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
-void PlayerFactory::LoadWaypoints_(shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = shared_ptr<sql::ResultSet>(statement->getResultSet());
-            GetEventDispatcher()->Dispatch(make_shared<WaypointEvent>("LoadWaypoints", player, result));
-        }
-    }
-    catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
-
-void PlayerFactory::LoadDraftSchematics_(shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = shared_ptr<sql::ResultSet>(statement->getResultSet());
-            while (result->next())
-            {
-                DraftSchematicData data;
-                data.schematic_id = result->getUInt("id");
-                data.schematic_crc = result->getUInt("schematic_id");
-                // didn't move here because you can't get faster than copying 2 ints
-                player->AddDraftSchematic(data);
-            }
-        }
     }
         catch(sql::SQLException &e)
     {
@@ -465,31 +283,7 @@ void PlayerFactory::PersistDraftSchematics_(const shared_ptr<Player>& player)
         LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
     }
 }
-void PlayerFactory::LoadQuestJournal_(shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = shared_ptr<sql::ResultSet>(statement->getResultSet());
-            while (result->next())
-            {
-                QuestJournalData data;
-                data.owner_id = result->getUInt64("quest_owner_id");
-                data.quest_crc = result->getUInt("quest_crc");
-                data.active_step_bitmask = result->getUInt("active_step_bitmask");
-                data.completed_step_bitmask = result->getUInt("completed_step_bitmask");
-                data.completed_flag = result->getUInt("completed") == 1;
-                player->AddQuest(move(data));
-            }
-        }
-    }
-        catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
+
 void PlayerFactory::PersistQuestJournal_(const shared_ptr<Player>& player)
 {
     try 
@@ -516,32 +310,7 @@ void PlayerFactory::PersistQuestJournal_(const shared_ptr<Player>& player)
         LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
     }
 }
-void PlayerFactory::LoadForceSensitiveQuests_(shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = shared_ptr<sql::ResultSet>(statement->getResultSet());
-            while (result->next())
-            {
-                if (result->getUInt("completed") == 1)
-                {
-                    player->AddCompletedForceSensitiveQuest(result->getUInt("quest_mask"));
-                }
-                else
-                {
-                    player->AddCurrentForceSensitiveQuest(result->getUInt("quest_mask"));
-                }
-            }
-        }
-    }
-        catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
+
 void PlayerFactory::PersistForceSensitiveQuests_(const shared_ptr<Player>& player)
 {
     try 
@@ -599,44 +368,7 @@ void PlayerFactory::PersistFriends_(const shared_ptr<Player>& player)
         LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
     }
 }
-void PlayerFactory::LoadFriends_(shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = unique_ptr<sql::ResultSet>(statement->getResultSet());
-            while (result->next())
-            {
-               player->AddFriend(result->getString("custom_name"), result->getUInt64("id"));
-            }
-        }
-    }
-        catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
-void PlayerFactory::LoadIgnoredList_(shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement)
-{
-    try 
-    {
-        if (statement->getMoreResults())
-        {
-            auto result = unique_ptr<sql::ResultSet>(statement->getResultSet());
-            while (result->next())
-            {
-               player->IgnorePlayer(result->getString("custom_name"), result->getUInt64("id"));
-            }
-        }
-    }
-        catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-}
+
 void PlayerFactory::PersistIgnoredList_(const shared_ptr<Player>& player)
 {
     try 
@@ -684,11 +416,14 @@ void PlayerFactory::LoadStatusFlags_(const std::shared_ptr<sql::Connection>& con
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
     {
-        player->AddStatusFlag(static_cast<StatusFlags>(result->getUInt("flag")));
-    }
+        while (result->next())
+        {
+            player->AddStatusFlag(static_cast<StatusFlags>(result->getUInt("flag")));
+        }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadProfileFlags_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -698,11 +433,14 @@ void PlayerFactory::LoadProfileFlags_(const std::shared_ptr<sql::Connection>& co
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
-    {
-        player->AddProfileFlag(static_cast<ProfileFlags>(result->getUInt("flag")));
-    }
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
+    { 
+        while (result->next())
+        {
+            player->AddProfileFlag(static_cast<ProfileFlags>(result->getUInt("flag")));
+        }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadBadges_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -712,11 +450,14 @@ void PlayerFactory::LoadBadges_(const std::shared_ptr<sql::Connection>& connecti
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
-    {
-        player->AddBadge(result->getUInt("badge"));
-    }
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());  
+    do
+    {  
+        while (result->next())
+        {
+            player->AddBadge(result->getUInt("badge"));
+        }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadDraftSchematics_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -726,15 +467,18 @@ void PlayerFactory::LoadDraftSchematics_(const std::shared_ptr<sql::Connection>&
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
     {
-        DraftSchematicData data;
-        data.schematic_id = result->getUInt("id");
-        data.schematic_crc = result->getUInt("schematic_id");
-        // didn't move here because you can't get faster than copying 2 ints
-        player->AddDraftSchematic(data);
-    }
+        while (result->next())
+        {
+            DraftSchematicData data;
+            data.schematic_id = result->getUInt("id");
+            data.schematic_crc = result->getUInt("schematic_id");
+            // didn't move here because you can't get faster than copying 2 ints
+            player->AddDraftSchematic(data);
+        }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadFriends_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -744,11 +488,14 @@ void PlayerFactory::LoadFriends_(const std::shared_ptr<sql::Connection>& connect
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
     {
-        player->AddFriend(result->getString("custom_name"), result->getUInt64("id"));
-    }
+        while (result->next())
+        {
+            player->AddFriend(result->getString("custom_name"), result->getUInt64("id"));
+        }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadForceSensitiveQuests_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -758,18 +505,21 @@ void PlayerFactory::LoadForceSensitiveQuests_(const std::shared_ptr<sql::Connect
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
-    {
-        if (result->getUInt("completed") == 1)
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
+    {  
+        while (result->next())
         {
-            player->AddCompletedForceSensitiveQuest(result->getUInt("quest_mask"));
+            if (result->getUInt("completed") == 1)
+            {
+                player->AddCompletedForceSensitiveQuest(result->getUInt("quest_mask"));
+            }
+            else
+            {
+                player->AddCurrentForceSensitiveQuest(result->getUInt("quest_mask"));
+            }
         }
-        else
-        {
-            player->AddCurrentForceSensitiveQuest(result->getUInt("quest_mask"));
-        }
-    }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadIgnoredList_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -779,11 +529,14 @@ void PlayerFactory::LoadIgnoredList_(const std::shared_ptr<sql::Connection>& con
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
-    {
-        player->IgnorePlayer(result->getString("custom_name"), result->getUInt64("id"));
-    }
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
+    {  
+        while (result->next())
+        {
+            player->IgnorePlayer(result->getString("custom_name"), result->getUInt64("id"));
+        }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadQuestJournal_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -793,17 +546,20 @@ void PlayerFactory::LoadQuestJournal_(const std::shared_ptr<sql::Connection>& co
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
     {
-        QuestJournalData data;
-        data.owner_id = result->getUInt64("quest_owner_id");
-        data.quest_crc = result->getUInt("quest_crc");
-        data.active_step_bitmask = result->getUInt("active_step_bitmask");
-        data.completed_step_bitmask = result->getUInt("completed_step_bitmask");
-        data.completed_flag = result->getUInt("completed") == 1;
-        player->AddQuest(std::move(data));
-    }
+        while (result->next())
+        {
+            QuestJournalData data;
+            data.owner_id = result->getUInt64("quest_owner_id");
+            data.quest_crc = result->getUInt("quest_crc");
+            data.active_step_bitmask = result->getUInt("active_step_bitmask");
+            data.completed_step_bitmask = result->getUInt("completed_step_bitmask");
+            data.completed_flag = result->getUInt("completed") == 1;
+            player->AddQuest(std::move(data));
+        }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadWaypoints_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -813,12 +569,15 @@ void PlayerFactory::LoadWaypoints_(const std::shared_ptr<sql::Connection>& conne
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
-    {
-        //auto result = shared_ptr<sql::ResultSet>(statement->getResultSet());
-        //GetEventDispatcher()->Dispatch(make_shared<WaypointEvent>("LoadWaypoints", player, result));
-    }
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
+    {   
+        while (result->next())
+        {
+            //auto result = shared_ptr<sql::ResultSet>(statement->getResultSet());
+            //GetEventDispatcher()->Dispatch(make_shared<WaypointEvent>("LoadWaypoints", player, result));
+        }
+    } while(statement->getMoreResults());
 }
 
 void PlayerFactory::LoadXP_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player)
@@ -828,9 +587,12 @@ void PlayerFactory::LoadXP_(const std::shared_ptr<sql::Connection>& connection, 
     
     statement->setUInt64(1, player->GetObjectId());
 
-    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());    
-    while (result->next())
-    {
-        player->AddExperience(XpData(result->getString("name"), result->getUInt("value")));
-    }
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
+    { 
+        while (result->next())
+        {
+            player->AddExperience(XpData(result->getString("name"), result->getUInt("value")));
+        }
+    } while(statement->getMoreResults());
 }

--- a/src/swganh_core/object/player/player_factory.h
+++ b/src/swganh_core/object/player/player_factory.h
@@ -25,6 +25,9 @@ namespace object {
 		typedef Player ObjectType;
 
         PlayerFactory(swganh::app::SwganhKernel* kernel);
+
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
+
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
@@ -36,6 +39,7 @@ namespace object {
         void RegisterEventHandlers();
     private:
         // Helpers
+        
         void LoadStatusFlags_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void LoadProfileFlags_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void LoadBadges_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
@@ -56,6 +60,17 @@ namespace object {
         void LoadIgnoredList_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void RemoveFromIgnoredList_(const std::shared_ptr<Player>& player, uint64_t ignore_player_id);
         void PersistIgnoredList_(const std::shared_ptr<Player>& player);
+        
+        void LoadStatusFlags_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+        void LoadProfileFlags_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+        void LoadBadges_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+        void LoadDraftSchematics_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+        void LoadFriends_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+        void LoadForceSensitiveQuests_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+        void LoadIgnoredList_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+        void LoadQuestJournal_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+        void LoadWaypoints_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
+		void LoadXP_(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Player>& player);
     };
 
 }}  // namespace swganh::object

--- a/src/swganh_core/object/player/player_factory.h
+++ b/src/swganh_core/object/player/player_factory.h
@@ -31,33 +31,21 @@ namespace object {
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
+
 		virtual void PersistChangedObjects();
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
         
         void RegisterEventHandlers();
     private:
-        // Helpers
-        
-        void LoadStatusFlags_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
-        void LoadProfileFlags_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
-        void LoadBadges_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
 		void PersistBadges_(const std::shared_ptr<Player>& player);
-		void LoadXP_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void PersistXP_(const std::shared_ptr<Player>& player);
-        void LoadWaypoints_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void PersistWaypoints_(const std::shared_ptr<Player>& player);
-        void LoadDraftSchematics_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void PersistDraftSchematics_(const std::shared_ptr<Player>& player);
-        void LoadQuestJournal_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void PersistQuestJournal_(const std::shared_ptr<Player>& player);
-        void LoadForceSensitiveQuests_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void PersistForceSensitiveQuests_(const std::shared_ptr<Player>& player);
-        void LoadFriends_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void PersistFriends_(const std::shared_ptr<Player>& player);
         void RemoveFriend_(const std::shared_ptr<Player>& player, uint64_t friend_id);
-        void LoadIgnoredList_(std::shared_ptr<Player> player, const std::shared_ptr<sql::Statement>& statement);
         void RemoveFromIgnoredList_(const std::shared_ptr<Player>& player, uint64_t ignore_player_id);
         void PersistIgnoredList_(const std::shared_ptr<Player>& player);
         

--- a/src/swganh_core/object/resource_container/resource_container_factory.cc
+++ b/src/swganh_core/object/resource_container/resource_container_factory.cc
@@ -10,7 +10,11 @@ using namespace swganh::object;
 
 ResourceContainerFactory::ResourceContainerFactory(swganh::app::SwganhKernel* kernel)
 	: TangibleFactory(kernel)
+{}
+
+void ResourceContainerFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    TangibleFactory::LoadFromStorage(connection, object);
 }
 
 uint32_t ResourceContainerFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
@@ -22,11 +26,6 @@ uint32_t ResourceContainerFactory::PersistObject(const shared_ptr<Object>& objec
 void ResourceContainerFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> ResourceContainerFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    return make_shared<ResourceContainer>();
 }
 
 shared_ptr<Object> ResourceContainerFactory::CreateObject()

--- a/src/swganh_core/object/resource_container/resource_container_factory.h
+++ b/src/swganh_core/object/resource_container/resource_container_factory.h
@@ -23,13 +23,13 @@ namespace object {
 		typedef ResourceContainer ObjectType;
 
 		 ResourceContainerFactory(swganh::app::SwganhKernel* kernel);
+         
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 		virtual void PersistChangedObjects(){}
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
-
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
 

--- a/src/swganh_core/object/ship/ship_factory.cc
+++ b/src/swganh_core/object/ship/ship_factory.cc
@@ -8,6 +8,11 @@ using namespace std;
 using namespace swganh::object;
 using namespace swganh::object;
 
+void ShipFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
+{
+    ObjectFactory::LoadFromStorage(connection, object);
+}
+
 uint32_t ShipFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
 	uint32_t counter = 1;
@@ -18,11 +23,6 @@ uint32_t ShipFactory::PersistObject(const shared_ptr<Object>& object, bool persi
 void ShipFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> ShipFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    return make_shared<Ship>();
 }
 
 shared_ptr<Object> ShipFactory::CreateObject()

--- a/src/swganh_core/object/ship/ship_factory.h
+++ b/src/swganh_core/object/ship/ship_factory.h
@@ -11,11 +11,13 @@ namespace object {
     class ShipFactory : public swganh::object::ObjectFactory
 	{
     public:
-        virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
-		virtual void PersistChangedObjects(){}
-        void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
+        virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
+		
+        virtual void PersistChangedObjects(){}
+        
+        void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
     };

--- a/src/swganh_core/object/static/static_factory.cc
+++ b/src/swganh_core/object/static/static_factory.cc
@@ -10,7 +10,11 @@ using namespace swganh::object;
 
 StaticFactory::StaticFactory(swganh::app::SwganhKernel* kernel)
 	: ObjectFactory(kernel)
+{}
+
+void StaticFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    ObjectFactory::LoadFromStorage(connection, object);
 }
 
 uint32_t StaticFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
@@ -23,11 +27,6 @@ uint32_t StaticFactory::PersistObject(const shared_ptr<Object>& object, bool per
 void StaticFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> StaticFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    return make_shared<Static>();
 }
 
 shared_ptr<Object> StaticFactory::CreateObject()

--- a/src/swganh_core/object/static/static_factory.h
+++ b/src/swganh_core/object/static/static_factory.h
@@ -23,14 +23,15 @@ namespace object {
     public:
 		typedef Static ObjectType;
 
-		 StaticFactory(swganh::app::SwganhKernel* kernel);
+		StaticFactory(swganh::app::SwganhKernel* kernel);
 
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
+        
 		virtual void PersistChangedObjects(){}
+        
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
-
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
     };

--- a/src/swganh_core/object/tangible/tangible_factory.cc
+++ b/src/swganh_core/object/tangible/tangible_factory.cc
@@ -89,8 +89,9 @@ void TangibleFactory::PersistChangedObjects()
 uint32_t TangibleFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
 	uint32_t counter = 1;
-	if (persist_inherited)
-		ObjectFactory::PersistObject(object, persist_inherited);
+
+	ObjectFactory::PersistObject(object, persist_inherited);
+
     try 
     {
         auto conn = GetDatabaseManager()->getConnection("galaxy");
@@ -105,8 +106,7 @@ uint32_t TangibleFactory::PersistObject(const shared_ptr<Object>& object, bool p
         statement->setInt(counter++, tangible->GetCondition());
         statement->setInt(counter++, tangible->GetMaxCondition());
         statement->setBoolean(counter++, tangible->IsStatic());
-        statement->executeUpdate();
-		
+        statement->executeUpdate();		
     }
     catch(sql::SQLException &e)
     {

--- a/src/swganh_core/object/tangible/tangible_factory.h
+++ b/src/swganh_core/object/tangible/tangible_factory.h
@@ -26,6 +26,9 @@ namespace object {
         typedef Tangible ObjectType;
 
         TangibleFactory(swganh::app::SwganhKernel* kernel);
+
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
+
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);

--- a/src/swganh_core/object/tangible/tangible_factory.h
+++ b/src/swganh_core/object/tangible/tangible_factory.h
@@ -32,15 +32,12 @@ namespace object {
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
 
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
+
 		virtual void PersistChangedObjects();
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
-		void CreateTangibleFromStorage(std::shared_ptr<swganh::object::Tangible> tangible);
-        void CreateTangible(const std::shared_ptr<Tangible>& tangible, const std::shared_ptr<sql::Statement>& statement);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
         
         virtual void RegisterEventHandlers();
-    private:
     };
 
 }}  // namespace swganh::object

--- a/src/swganh_core/object/waypoint/waypoint_factory.cc
+++ b/src/swganh_core/object/waypoint/waypoint_factory.cc
@@ -103,8 +103,9 @@ void WaypointFactory::LoadWaypoints(const shared_ptr<Player>& player, const shar
 uint32_t WaypointFactory::PersistObject(const shared_ptr<Object>& object, bool persist_inherited)
 {
 	uint32_t counter = 1;
-	if (persist_inherited)
-		IntangibleFactory::PersistObject(object, persist_inherited);
+	
+    IntangibleFactory::PersistObject(object, persist_inherited);
+
     if (object)
     {
         try 

--- a/src/swganh_core/object/waypoint/waypoint_factory.cc
+++ b/src/swganh_core/object/waypoint/waypoint_factory.cc
@@ -32,10 +32,38 @@ WaypointFactory::WaypointFactory(swganh::app::SwganhKernel* kernel)
 {
     RegisterEventHandlers();
 }
+
+void WaypointFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
+{
+    IntangibleFactory::LoadFromStorage(connection, object);
+
+    auto waypoint = std::dynamic_pointer_cast<Waypoint>(object);
+    if(!waypoint)
+    {
+        throw InvalidObject("Object requested for loading is not Intangible");
+    }
+
+    auto statement = std::shared_ptr<sql::PreparedStatement>
+        (connection->prepareStatement("CALL sp_GetWaypoint(?);"));
+    
+    statement->setUInt64(1, waypoint->GetObjectId());
+
+    auto result = std::unique_ptr<sql::ResultSet>(statement->executeQuery());
+    do
+    {
+        while (result->next())
+        {
+            result->getUInt("active") == 0 ? waypoint->DeActivate() : waypoint->Activate();
+            waypoint->SetColor(result->getString("color"));
+        }
+    } while(statement->getMoreResults());
+}
+
 void WaypointFactory::RegisterEventHandlers()
 {
 	GetEventDispatcher()->Subscribe("PersistWaypoints", std::bind(&WaypointFactory::PersistHandler, this, std::placeholders::_1));
 }
+
 void WaypointFactory::PersistChangedObjects()
 {
 	std::set<shared_ptr<Object>> persisted;
@@ -116,42 +144,6 @@ uint32_t WaypointFactory::PersistObject(const shared_ptr<Object>& object, bool p
 void WaypointFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> WaypointFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-    auto waypoint = make_shared<Waypoint>();
-    waypoint->SetObjectId(object_id);
-    try{
-        auto conn = GetDatabaseManager()->getConnection("galaxy");
-        auto statement = shared_ptr<sql::Statement>(conn->createStatement());
-        stringstream ss;
-        ss << "CALL sp_GetWaypoint(" << object_id << ");";
-        auto result = shared_ptr<sql::ResultSet>(statement->executeQuery(ss.str()));
-        CreateBaseObjectFromStorage(waypoint, result);
-        if (statement->getMoreResults())
-        {
-            result.reset(statement->getResultSet());
-            while (result->next())
-            {
-			    uint16_t activated = result->getUInt("active");
-                activated == 0 ? waypoint->DeActivate() : waypoint->Activate();
-                waypoint->SetColor(result->getString("color"));
-            }
-        }
-
-		//Clear us from the db persist update queue.
-		boost::lock_guard<boost::mutex> lock(persisted_objects_mutex_);
-		auto find_itr = persisted_objects_.find(waypoint);
-		if(find_itr != persisted_objects_.end())
-			persisted_objects_.erase(find_itr);
-    }
-    catch(sql::SQLException &e)
-    {
-        LOG(error) << "SQLException at " << __FILE__ << " (" << __LINE__ << ": " << __FUNCTION__ << ")";
-        LOG(error) << "MySQL Error: (" << e.getErrorCode() << ": " << e.getSQLState() << ") " << e.what();
-    }
-    return waypoint;
 }
 
 shared_ptr<Object> WaypointFactory::CreateObject()

--- a/src/swganh_core/object/waypoint/waypoint_factory.h
+++ b/src/swganh_core/object/waypoint/waypoint_factory.h
@@ -20,18 +20,20 @@ namespace object {
 		typedef Waypoint ObjectType;
 
         WaypointFactory(swganh::app::SwganhKernel* kernel);
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
-		void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
-		virtual void PersistChangedObjects();
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
+		
+        void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
+		
+        virtual void PersistChangedObjects();
 
         std::shared_ptr<swganh::object::Object> CreateObject();
 
         void LoadWaypoints(const std::shared_ptr<swganh::object::Player>& player, const std::shared_ptr<sql::ResultSet> result_set);
 
         virtual void RegisterEventHandlers();
-    private:
     };
 
 }}  // namespace swganh::object

--- a/src/swganh_core/object/weapon/weapon_factory.cc
+++ b/src/swganh_core/object/weapon/weapon_factory.cc
@@ -11,7 +11,11 @@ using namespace swganh::object;
 
 WeaponFactory::WeaponFactory(swganh::app::SwganhKernel* kernel)
 	: TangibleFactory(kernel)
+{}
+
+void WeaponFactory::LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object)
 {
+    TangibleFactory::LoadFromStorage(connection, object);
 }
 
 void WeaponFactory::PersistChangedObjects()
@@ -36,14 +40,6 @@ uint32_t WeaponFactory::PersistObject(const shared_ptr<Object>& object, bool per
 void WeaponFactory::DeleteObjectFromStorage(const shared_ptr<Object>& object)
 {
 	ObjectFactory::DeleteObjectFromStorage(object);
-}
-
-shared_ptr<Object> WeaponFactory::CreateObjectFromStorage(uint64_t object_id)
-{
-	auto weapon = make_shared<Weapon>();
-	weapon->SetObjectId(object_id);
-	TangibleFactory::CreateTangibleFromStorage(weapon);
-	return weapon;
 }
 
 shared_ptr<Object> WeaponFactory::CreateObject()

--- a/src/swganh_core/object/weapon/weapon_factory.h
+++ b/src/swganh_core/object/weapon/weapon_factory.h
@@ -14,13 +14,15 @@ namespace object {
     public:
 		typedef Weapon ObjectType;
 
-		 WeaponFactory(swganh::app::SwganhKernel* kernel);
+		WeaponFactory(swganh::app::SwganhKernel* kernel);
+        
+        virtual void LoadFromStorage(const std::shared_ptr<sql::Connection>& connection, const std::shared_ptr<Object>& object);
 
         virtual uint32_t PersistObject(const std::shared_ptr<swganh::object::Object>& object, bool persist_inherited = false);
-		virtual void PersistChangedObjects();
+		
+        virtual void PersistChangedObjects();
+        
         void DeleteObjectFromStorage(const std::shared_ptr<swganh::object::Object>& object);
-
-        std::shared_ptr<swganh::object::Object> CreateObjectFromStorage(uint64_t object_id);
 
         std::shared_ptr<swganh::object::Object> CreateObject();
     };

--- a/src/swganh_core/simulation/simulation_service.cc
+++ b/src/swganh_core/simulation/simulation_service.cc
@@ -392,8 +392,6 @@ public:
             throw std::runtime_error("Invalid scene selected for object");
         }
 
-		object->SetCollidable(false);
-
 		// CmdStartScene
         CmdStartScene start_scene;
         start_scene.ignore_layout = 0;
@@ -405,36 +403,14 @@ public:
         start_scene.galaxy_time = 0;
 
 		client->SendTo(start_scene, boost::optional<Session::SequencedCallback>(
-			[=](uint16_t sequence){
-				LOG(warning) << "here.";
+			[=](uint16_t sequence)
+        {
+				StartControllingObject(object, client);
+
 				if(object->GetContainer() == nullptr)
 				{
 					scene->AddObject(object);
 				}
-
-				//Attach the controller
-				StartControllingObject(object, client);
-
-				//Make sure the controller gets his awareness creates
-				//regardless of the current state of awareness.
-				auto controller = object->GetController();
-				scene->ViewObjects(object, 0, true, [&] (std::shared_ptr<swganh::object::Object> aware) {
-					if(aware->__HasAwareObject(object) && !aware->IsInSnapshot())
-					{
-						//Send create manually
-						aware->Subscribe(controller);
-						aware->SendCreateByCrc(controller);
-						aware->CreateBaselines(controller);
-					}
-					else
-					{
-						aware->AddAwareObject(object);
-						object->AddAwareObject(aware);
-					}
-				});
-				
-
-				object->SetCollidable(true);
 		}));
     }
 

--- a/src/swganh_core/simulation/simulation_service_binding.h
+++ b/src/swganh_core/simulation/simulation_service_binding.h
@@ -32,6 +32,7 @@ void exportSimulationService()
 	typedef void (SimulationServiceInterface::*TransferObjectToSceneObjectBinding)(shared_ptr<swganh::object::Object>, const std::string&);
 	typedef void (SimulationServiceInterface::*TransferObjectToSceneAndPositionBinding)(uint64_t, const std::string&, float, float, float);
 	typedef void (SimulationServiceInterface::*TransferObjectToSceneObjectAndPositionBinding)(shared_ptr<swganh::object::Object>, const std::string&, float, float, float);
+    typedef std::shared_ptr<swganh::object::Object> (SimulationServiceInterface::*LoadObjectByIdBinding)(uint64_t object_id);
 
 	enum_<PermissionType>("ContainerPermission")
 		.value("DEFAULT", DEFAULT_PERMISSION)
@@ -46,7 +47,7 @@ void exportSimulationService()
 
     class_<SimulationServiceInterface, std::shared_ptr<SimulationServiceInterface>, boost::noncopyable>("SimulationService", "The simulation service handles the current scenes aka planets", no_init)
         .def("persist", &SimulationServiceInterface::PersistRelatedObjects, "persists the specified object and it's containing objects")
-        .def("findObjectById", GetObjectByIdBinding(&SimulationServiceInterface::GetObjectById), "Finds an object by its id")
+        .def("findObjectById", GetObjectByIdBinding(&SimulationServiceInterface::LoadObjectById), "Finds an object by its id")
 		.def("transfer", TransferObjectToSceneBinding(&SimulationServiceInterface::TransferObjectToScene), "transfers the object to a new scene")
 		.def("transfer", TransferObjectToSceneObjectBinding(&SimulationServiceInterface::TransferObjectToScene), "transfers the object to a new scene")
 		.def("transfer", TransferObjectToSceneAndPositionBinding(&SimulationServiceInterface::TransferObjectToScene), "transfers the object to a new scene and changes the position")

--- a/src/swganh_core/simulation/simulation_service_binding.h
+++ b/src/swganh_core/simulation/simulation_service_binding.h
@@ -45,7 +45,7 @@ void exportSimulationService()
 		;
 
     class_<SimulationServiceInterface, std::shared_ptr<SimulationServiceInterface>, boost::noncopyable>("SimulationService", "The simulation service handles the current scenes aka planets", no_init)
-        .def("persist", &SimulationServiceInterface::PersistObject, "persists the specified object and it's containing objects")
+        .def("persist", &SimulationServiceInterface::PersistRelatedObjects, "persists the specified object and it's containing objects")
         .def("findObjectById", GetObjectByIdBinding(&SimulationServiceInterface::GetObjectById), "Finds an object by its id")
 		.def("transfer", TransferObjectToSceneBinding(&SimulationServiceInterface::TransferObjectToScene), "transfers the object to a new scene")
 		.def("transfer", TransferObjectToSceneObjectBinding(&SimulationServiceInterface::TransferObjectToScene), "transfers the object to a new scene")
@@ -58,5 +58,7 @@ void exportSimulationService()
 		.def("createObject", &SimulationServiceInterface::CreateObjectFromTemplate, CreateOverload(args("template_name", "permission_type", "is_persisted", "object_id"), "Creates an object of the given template"))
 		.def("removeObject", &SimulationServiceInterface::RemoveObject, "Removes an object from the simulation (delete).")
 		.def("removeObjectById", &SimulationServiceInterface::RemoveObjectById, "Removes an object from the simulation by id (delete).")
+        .def("getSceneNameById", &SimulationServiceInterface::SceneNameById, "Returns a scenes name given its id")
+        .def("getSceneIdByName", &SimulationServiceInterface::SceneIdByName, "Returns a scenes id given its name")
 		;
 }


### PR DESCRIPTION
This fix takes out one of the areas we are "brute forcing" information to the client:

When a character is created we were adding them to the scene, this means the object was already in the scene and had its awareness built before the client began controlling it. This meant that the client had to be forced the creates for object in range on logging in.

Now the object is not added to the scene during the creation phase, instead letting the normal login process to select and load the character into the scene.
